### PR TITLE
Use relative paths for assets

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -17,7 +17,7 @@ title: Home
         </ul>
       </div>
       <div class="govuk-grid-column-one-third">
-        <img src="/assets/images/home-hero.jpg" alt="Teacher smiling and talking with two students in a classroom"
+        <img src="./assets/images/home-hero.jpg" alt="Teacher smiling and talking with two students in a classroom"
           class="dfe-hero-image">
       </div>
     </div>
@@ -63,7 +63,7 @@ title: Home
 <div class="govuk-grid-row  govuk-width-container dfe-width-container">
   <div class="govuk-grid-column-one-third">
     <div class="dfe-icon-container">
-      <img src="/assets/images/chat.svg" alt="Chat icon" class="dfe-icon">
+      <img src="./assets/images/chat.svg" alt="Chat icon" class="dfe-icon">
       <h2 class="govuk-heading-m">Help to improve our service</h2>
       <p class="govuk-body">Provide us with your feedback to help us improve our service on workload and wellbeing for
         all school staff.</p>
@@ -72,7 +72,7 @@ title: Home
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="dfe-icon-container">
-      <img src="/assets/images/idea.svg" alt="Idea icon" class="dfe-icon">
+      <img src="./assets/images/idea.svg" alt="Idea icon" class="dfe-icon">
       <h2 class="govuk-heading-m">Share your ideas with us</h2>
       <p class="govuk-body">We'd love to know what you are doing or have done to help with workload and wellbeing in
         your school.</p>
@@ -81,7 +81,7 @@ title: Home
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="dfe-icon-container">
-      <img src="/assets/images/mail.svg" alt="Mail icon" class="dfe-icon">
+      <img src="./assets/images/mail.svg" alt="Mail icon" class="dfe-icon">
       <h2 class="govuk-heading-m">Contact us for support</h2>
       <p class="govuk-body">Contact us via this email: support@education.gov.uk, if you need further support.</p>
       <a href="mailto:support@education.gov.uk" class="govuk-link">Contact us for support</a>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -6,7 +6,7 @@
   <title>
     <%= @item[:title] %> - Improving Workload and Well being for school staff
   </title>
-  <link href='/css/application.css' rel='stylesheet'>
+  <link href='./css/application.css' rel='stylesheet'>
   <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
 </head>
 
@@ -15,8 +15,8 @@
     <div class="dfe-width-container dfe-header__container">
       <div class="dfe-header__logo">
         <a class="dfe-header__link dfe-header__link--service " href="#" aria-label="DfE homepage">
-          <img src="/assets/images/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
-          <img src="/assets/images/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
+          <img src="./assets/images/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
+          <img src="./assets/images/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
           <span class="dfe-header__service-name">
             Improving Workload and Well being for school staff
           </span>


### PR DESCRIPTION
There are issues finding assets in GitHub pages. The assests are expected at the project root, but in GitHub pages they are under the sub-directory `improve-school-workload-and-wellbeing`

<img width="1232" alt="image" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/85567720/1c86ade5-e371-47d5-ad15-7f427101f4b4">

This PR adjusts the css and images paths to be relative.

<img width="1232" alt="image" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/85567720/b5227bcf-981c-4188-a739-de82e53c6ae7">

