### PR TITLE
Add Google Analytics

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -2,6 +2,15 @@
 <html lang="en">
 
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-46725WKCY4"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-46725WKCY4');
+  </script>
   <meta charset="utf-8">
   <title>
     <%= @item[:title] %> - Improve workload and wellbeing for school staff


### PR DESCRIPTION
Start setting up analytics - https://trello.com/c/xD2BSa0x

As per the setup [instructions](https://support.google.com/analytics/answer/9304153) we are adding the customised script tag to the `head` section of all pages.

<img width="1316" alt="image" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/85567720/421b0618-da27-4501-b75d-f9e852e70383">
