### PR TITLE
Fix typo on explore resources evaluate page

### DIFF
--- a/content/explore-all-resources/evaluate-workload-measures.html.erb
+++ b/content/explore-all-resources/evaluate-workload-measures.html.erb
@@ -25,7 +25,7 @@ layout: /explore_resources.html.erb
     tag_colour: "green",
     details: {
       resource_type: "Template",
-      create_by: "Bedford Academy"
+      created_by: "Bedford Academy"
     }
   )%>
 


### PR DESCRIPTION
There's a typo I missed when reviewing the PR for the Explore all resources page.

It changes it from 'create' to 'created'.