### PR TITLE
[285] Add 'Parental communications policy' resource

### DIFF
--- a/content/explore-all-resources/communications.html.erb
+++ b/content/explore-all-resources/communications.html.erb
@@ -19,8 +19,8 @@ layout: /explore_resources.html.erb
   )%>
 
   <%= render('/partials/explore_resource_card.*',
-    title: "Example communications policy",
-    href: "#",
+    title: "Parental communications policy",
+    href:  "#{@base_url}/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy",
     tag:  "Communications",
     tag_colour: "purple",
     details: {

--- a/content/workload-reduction-toolkit/address-workload-issues/communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications.html.erb
@@ -56,8 +56,8 @@ title: Communications
             tag: "Presentation")%>
 
           <%= render('/partials/resource_card.*',
-            title: "Example communications policy",
-            href: "#",
+            title: "Parental communications policy",
+            href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy",
             body: "Develop a communications policy for parental engagement.",
             tag: "Example",
             details: { reading_time: "6 minutes", created_by: "St Edward's RC/CoE School (Secondary)" } )%>

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy.md
@@ -1,0 +1,168 @@
+---
+title: Parental communications policy
+layout: /markdown_resource.html.erb
+---
+
+# Parental communications policy
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: St Edward's RC/CoE School
+
+**Location**: Dorset
+
+**Type**: Secondary
+
+**Number of pupils**: 1000
+
+**Contact details**: Email headteacher Michael Antram at <m.antram@st-edwards.poole.sch.uk>
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+         Our parental communications policy has led to:
+      </p>
+      <p>
+        <ul>
+         <li>
+            a reduction in the demands to respond to parental emails in the
+            evenings and weekends, so that work and home boundaries are clearer
+         </li>
+         <li>
+            parents and carers better understand the context in which teachers
+            are working, and can modify their expectations of an immediate reply
+         </li>
+         <li>
+            communication is distributed and directed more appropriately across
+            the staff team
+         </li>
+        </ul>
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Michael Antram
+
+{inset-text}
+
+We developed this policy by asking teachers about the factors that added to
+their workload. A key finding of this consultation was that the need to
+communicate with parents and carers placed a significant demand upon our
+teachers within a busy teaching day. As a school we decided that we had to
+manage both parental expectations of teachers and ensure high standards of
+home-school communications.
+
+We also looked at using electronic tools that assist communication to parents
+through text, email, and newsletter and can facilitate paying for trips or
+resources.
+
+{/inset-text}
+
+## The parental communications policy
+
+It is very important to us that we work closely in partnership with parents and
+carers, and communication between home and school is key. We recognise however
+that it can often be difficult communicating with teachers because they have a
+very full timetable; and we recognise that parents and carers also have very
+busy lives.
+
+## Contacting the school
+
+Communication by email or student planner are the preferred method.
+
+Notes in student planners are by far the best way to get a message to a teacher
+promptly and should be used for the majority of everyday communication. The
+student is responsible for showing the note to the correct teacher. This is the
+best way to ask them to contact you if you require a more detailed conversation.
+
+Teachers want to respond to parental queries at the earliest opportunity and
+will do their best to do so. However, the majority of teachers’ time is taken up
+teaching and preparing for lessons. Teachers’ responsibilities extend beyond the
+classroom, and they may be unable to respond to you on the day a query is made.
+We have also agreed with staff that there is no expectation to respond to
+queries during their personal time.
+
+## Phoning school staff
+
+Please use the main reception number to leave a message for a teacher to contact
+you.
+
+Reception staff will relay messages to teachers as soon as possible.
+
+If a call is urgent, please inform the receptionist who will attempt to find a
+senior member of staff to speak to you.
+
+We will try to respond to you within three working days, if not the same day.
+Please note lessons will never be interrupted for teachers to take calls.
+
+## Emailing school staff
+
+Please use staff email addresses if you need to contact staff directly.
+
+Teachers are not in a position to check emails consistently throughout the day
+and the school does not expect work email to be checked during a teacher’s
+personal time.
+
+We aim to respond to you as soon as possible and within three working days.
+Part-time staff may take longer to reply.
+
+## Scheduling meetings with school staff
+
+The day-to-day care, welfare and safety of your child is managed by the person
+who is placed closest to them.
+
+In the first instance, please approach the following members of staff who are
+responsible for your child in the following order:
+
+1. Form Tutor or Classroom Teacher (if query is relevant to a specific subject)
+
+2. Year Leader or Subject Leader (if query is relevant to a specific subject)
+
+3. Assistant Headteacher
+
+4. Deputy Headteacher
+
+5. Headteacher
+
+Meetings should always be pre-arranged with members of staff.
+
+If you urgently need to see someone, for instance if there is a serious family
+emergency or a child protection issue, please phone ahead and the reception staff
+will do their best to find a senior member of staff to see you.
+
+For non-urgent meetings we will aim to meet with you within five working days.
+The school will determine the level of urgency at its discretion, to enable it
+to manage multiple demands.
+
+## Receiving contact from the school
+
+Our preferred method of contacting you is via [insert contact system here].
+
+## Finding the school’s social media
+
+We use our social media channels to promote student achievements, subject
+information and generic educational information. You can find these by searching
+[insert social media profiles].
+
+## Following up communications to the school
+
+If you have not received a response from the school within three working days,
+please contact the school by emailing [insert school email] and we will chase up
+your enquiry.
+
+Communication with parents and carers is important to us, and we will continue
+to monitor this policy and our approach to improve the process further.


### PR DESCRIPTION
This PR can be used as an example of how to add a new resource.

## Changes made in this PR

- Added new Parental communications policy resource, accessible at `/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy`
- Linked new page from 'Explore all resources' page
- Linked new page from 'Communications' topic page

## Guidance to review

https://trello.com/c/obcz4Lqt/285-create-instructions-for-content-designers-and-devs-to-create-and-approve-pull-requests-for-the-service

<img width="1552" alt="Screenshot 2024-02-06 at 12 07 13" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/6bff5062-4703-4a3d-86c6-0c48657fee7c">
