### PR TITLE
[308 & 311] Mobile styling and homepage links

### DIFF
--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -28,6 +28,7 @@ $card-text-hover-color: govuk-colour("purple");
 
 .explore-resource-card__row-title {
   min-width: 30%;
+  margin-right: govuk-spacing(4);
 
   p {
     font-weight: bold;

--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -6,7 +6,10 @@ $card-text-color: govuk-colour("purple");
 $card-text-hover-color: govuk-colour("purple");
 
 .explore-resource-card-group {
-  margin: govuk-spacing(5) govuk-spacing(9);
+  margin-top: govuk-spacing(7);
+  @include govuk-media-query($from: tablet) {
+    margin: govuk-spacing(5) govuk-spacing(9);
+  }
 }
 
 .explore-resource-card {
@@ -57,6 +60,7 @@ $card-text-hover-color: govuk-colour("purple");
   position: relative;
   width: 100%;
   text-decoration: none;
+  margin: 0 govuk-spacing(5);
 
   p {
     text-decoration: none;
@@ -123,10 +127,9 @@ $card-text-hover-color: govuk-colour("purple");
 
 .card-group__item {
   display: flex;
-
   list-style-type: none;
   margin-bottom: 0;
-  padding: 0 govuk-spacing(5);
+  padding: 0;
 
   .icon-card,
   .dfe-card {
@@ -134,7 +137,6 @@ $card-text-hover-color: govuk-colour("purple");
   }
 
   @include mq($until: desktop) {
-
     .icon-card,
     .dfe-card {
       margin-bottom: govuk-spacing(3);
@@ -155,7 +157,6 @@ $card-text-hover-color: govuk-colour("purple");
 
 .icon-card--link {
   &.icon-card--clickable {
-
     &:hover,
     &:active {
       p {
@@ -174,7 +175,9 @@ $card-text-hover-color: govuk-colour("purple");
 }
 
 .dfe-card-container {
-  display: flex;
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+  }
 }
 
 .dfe-card {
@@ -231,6 +234,8 @@ $card-text-hover-color: govuk-colour("purple");
   color: govuk-colour("white");
   text-decoration: none;
   font-weight: bold;
+  padding: govuk-spacing(7);
+  margin-bottom: 0;
 }
 
 .dfe-card-header .govuk-heading-m {
@@ -256,5 +261,5 @@ $card-text-hover-color: govuk-colour("purple");
 }
 
 .dfe-card-body {
-  padding: govuk-spacing(5) govuk-spacing(7);
+  padding: govuk-spacing(7);
 }

--- a/content/assets/css/_feedback-sections.scss
+++ b/content/assets/css/_feedback-sections.scss
@@ -1,5 +1,7 @@
 .feedback-section-container {
-  display: flex;
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+  }
 }
 
 .govuk-grid-column-one-third {
@@ -23,7 +25,10 @@
 .feedback-section {
   width: 100%;
   display: flex;
-  margin: 0 govuk-spacing(6);
+  margin-top: govuk-spacing(4);
+  @include govuk-media-query($from: tablet) {
+    margin: 0 govuk-spacing(6);
+  }
 }
 
 .feedback-section__icon {

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -21,7 +21,6 @@
 
 // Remove margin from the last element
 @mixin remove-last-child-margin {
-
   p:last-child,
   ul:last-child,
   ol:last-child {
@@ -39,15 +38,19 @@
   background: $colour;
 }
 
-@mixin left-bordered-block($border-colour,
-  $background-colour: govuk-colour("white")) {
+@mixin left-bordered-block(
+  $border-colour,
+  $background-colour: govuk-colour("white")
+) {
   @include block;
   border-left: 10px solid $border-colour;
   background: $background-colour;
 }
 
-@mixin emphatic-block($background-colour,
-  $foreground-colour: govuk-colour("white")) {
+@mixin emphatic-block(
+  $background-colour,
+  $foreground-colour: govuk-colour("white")
+) {
   @include coloured-block($background-colour);
   padding: 2em 0;
   text-align: center;
@@ -75,10 +78,6 @@
 
 .govuk-width-container {
   max-width: 1200px;
-}
-
-.govuk-grid-column-one-third {
-  padding: 0px;
 }
 
 .govuk-grid-row {
@@ -111,7 +110,6 @@
   width: 75px;
   height: auto;
 }
-
 
 .dfe-content-page--header {
   background-color: #347ca9;
@@ -195,12 +193,12 @@
 }
 
 .govuk-button:hover {
-  background-color: #1D70B8;
+  background-color: #1d70b8;
 }
 
 .govuk-button:active {
-  background-color: #1D70B8;
-  border: 2px solid #FFDD00;
+  background-color: #1d70b8;
+  border: 2px solid #ffdd00;
 }
 
 .govuk-button:focus {
@@ -386,12 +384,14 @@ main {
     margin-bottom: govuk-spacing(7);
   }
 
-  .govuk-grid-column-two-thirds {
-    padding-right: govuk-spacing(9);
-  }
+  @include govuk-media-query($from: tablet) {
+    .govuk-grid-column-two-thirds {
+      padding-right: govuk-spacing(9);
+    }
 
-  .govuk-grid-column-one-third {
-    padding-left: govuk-spacing(6);
+    .govuk-grid-column-one-third {
+      padding-left: govuk-spacing(6);
+    }
   }
 }
 

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -104,6 +104,10 @@
 
 .dfe-icon-container--left {
   float: left;
+  margin: 0 govuk-spacing(4);
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(4);
+  }
 }
 
 .dfe-icon-container--left .dfe-icon {

--- a/content/main.html.erb
+++ b/content/main.html.erb
@@ -26,29 +26,28 @@ title: Home
 </div>
 
 <div class="govuk-main-wrapper">
-  <div class="govuk-grid-row govuk-width-container dfe-width-container">
-    <div class="dfe-card-container">
-      <div class="dfe-card">
-        <div class="dfe-card-header">
-          <h2 class="govuk-heading-m">
-            <a href="<%= @base_url %>/staff-wellbeing" class="govuk-link">Staff wellbeing</a>
-          </h2>
-        </div>
-        <div class="dfe-card-body">
-          <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
-        </div>
-      </div>
-      <div class="dfe-card">
-        <div class="dfe-card-header">
-          <h2 class="govuk-heading-m">
-            <a href="<%= @base_url %>/workload-reduction-toolkit" class="govuk-link">Workload reduction</a>
-          </h2>
-        </div>
-        <div class="dfe-card-body">
-          <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
-        </div>
-      </div>
-    </div>
+  <div class="govuk-width-container dfe-width-container">
+    <ul class="govuk-grid-row card-group">
+      <li class="govuk-grid-column-one-half card-group__item">
+        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/staff-wellbeing">
+          <p class="govuk-body-l dfe-card-header">
+            Staff wellbeing
+          </p>
+          <div class="dfe-card-body">
+            <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
+          </div>
+        </a>
+      </li>
+
+      <li class="govuk-grid-column-one-half card-group__item">
+        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit">
+          <p class=" govuk-body-l dfe-card-header">Workload reduction</p>
+          <div class="dfe-card-body">
+            <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
+          </div>
+        </a>
+      </li>
+    </ul>
   </div>
 </div>
 
@@ -66,6 +65,8 @@ title: Home
   </div>
 </div>
 
-<div class="govuk-main-wrapper">
-  <%= render '/partials/feedback.*' %>
+<div class="dfe-width-container govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-full">
+    <%= render '/partials/feedback.*' %>
+  </div>
 </div>

--- a/content/share-your-ideas.html.erb
+++ b/content/share-your-ideas.html.erb
@@ -24,7 +24,7 @@ title: Share your ideas
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container">
     <div class="govuk-grid-row govuk-!-margin-top-5">
-      <div class="dfe-icon-container--left govuk-!-margin-top-4">
+      <div class="dfe-icon-container--left">
         <img src="<%= @base_url %>/assets/images/idea.svg" alt="Idea icon" class="dfe-icon" />
       </div>
       <div class="govuk-grid-column-two-thirds govuk-!-margin-top-4 govuk-!-margin-bottom-9">

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -35,7 +35,7 @@ title: Workload reduction toolkit
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-third card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="#">
-          <p class="dfe-card-header govuk-!-padding-7 dfe-card-header--pink">
+          <p class="dfe-card-header dfe-card-header--pink">
             Identify workload issues
           </p>
           <div class="dfe-card-body">
@@ -46,7 +46,7 @@ title: Workload reduction toolkit
 
       <li class="govuk-grid-column-one-third card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues">
-          <p class="dfe-card-header govuk-!-padding-7 dfe-card-header--purple">Address workload issues</p>
+          <p class="dfe-card-header dfe-card-header--purple">Address workload issues</p>
           <div class="dfe-card-body">
             <p class="govuk-body">Take action to reduce workload</p>
           </div>
@@ -55,7 +55,7 @@ title: Workload reduction toolkit
 
       <li class="govuk-grid-column-one-third card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="#">
-          <p class="dfe-card-header govuk-!-padding-7 dfe-card-header--green">Evaluate workload measures</p>
+          <p class="dfe-card-header dfe-card-header--green">Evaluate workload measures</p>
           <div class="dfe-card-body">
             <p class="govuk-body">Track and evaluate workload reduction measures</p>
           </div>

--- a/content/workload-reduction-toolkit/address-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues.html.erb
@@ -31,6 +31,8 @@ title: Address workload issues
   </div>
 </div>
 
-<div class="govuk-main-wrapper">
-  <%= render '/partials/feedback.*' %>
+<div class="dfe-width-container govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-full">
+    <%= render '/partials/feedback.*' %>
+  </div>
 </div>

--- a/layouts/base.html
+++ b/layouts/base.html
@@ -8,6 +8,7 @@
   </title>
   <link href='<%= @base_url %>/css/application.css' rel='stylesheet'>
   <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body class="govuk-template__body  js-enabled">

--- a/layouts/workload_topic_section.html.erb
+++ b/layouts/workload_topic_section.html.erb
@@ -1,6 +1,6 @@
 <% wrapped_content=capture do %>
-  <div class="govuk-main-wrapper">
-    <div class="dfe-width-container govuk-grid-row two-column-page">
+  <div class="govuk-main-wrapper two-column-page">
+    <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="dfe-width-container govuk-grid-row">
           <h1 class="govuk-heading-l"><%= @item[:title] %></h1>
@@ -13,6 +13,7 @@
         </div>
       </div>
 
+    <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <hr class="govuk-section-break--thick">
 


### PR DESCRIPTION
## Changes in this PR

- Add viewport meta tag so that the site is correctly sized on all devices
- Mobile style updates (see screenshots below)
- Fix hover/active styles on homepage links

## Guidance to review

### Homepage links:
- Check hover and active styles for 'Staff wellbeing' and 'Workload reduction' box links.
  - the whole box is now clickable
  - your cursor turns to a pointer and text becomes underlined on hover (over whole box)
  - blue header turns yellow when active, not just the text
  - the text turns black when active, not white

- Before and after screenshots for active style:

<img width="1142" alt="Screenshot 2024-02-14 at 11 34 36" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/d23034fe-ed4c-4af2-9499-acf203d41d0c">

### Mobile things:
Visit the site on a mobile or right click -> inspect the page in the browser and view as different devices.
Check that all pages look better!

Things I've fixed (left screenshots are my fixes, right screenshots are currently in production):

### 1. Images don't bleed off the side:

<img width="1009" alt="Screenshot 2024-02-14 at 11 25 58" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/b2b7d026-eeb6-4be5-a7df-cbb71898c71f">

---

### 2. Homepage boxes display vertically:

<img width="1011" alt="Screenshot 2024-02-14 at 10 53 42" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/281fb907-9a38-4871-9ed6-70aa9c8a1fc9">

---

### 3. Feedback sections display vertically:

<img width="995" alt="Screenshot 2024-02-14 at 10 53 59" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/ed920d5a-7a1e-47fa-8e0e-edffffc039ac">

---

### 4. Workload topic columns full width:
 
<img width="1008" alt="Screenshot 2024-02-14 at 11 07 36" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/ae94a661-ad8e-4cc5-b9f9-7cb0981f7fa3">

---

### 5. Staff workload feedback section doesn't bleed off RHS:

<img width="997" alt="Screenshot 2024-02-14 at 11 08 06" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/09375d98-be6c-4a84-8740-a2e174862f97">

---

### 6. Individual resources columns full width:

<img width="1007" alt="Screenshot 2024-02-14 at 11 08 53" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/0bef5fda-1f86-466d-92db-5665ab287e46">

<img width="995" alt="Screenshot 2024-02-14 at 11 09 17" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/7227b0a2-13ac-419b-a324-9da926ea2e6e">

---

### 7. Fix 'How to share' box styling

<img width="1011" alt="Screenshot 2024-02-14 at 13 40 29" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/ee7a1447-8f37-456a-8e70-d61601ed0b39">
