### PR TITLE
[312] Add first wellbeing resource with 'colour scheme' feature

### DIFF
--- a/content/assets/css/_info-box.scss
+++ b/content/assets/css/_info-box.scss
@@ -32,3 +32,13 @@
     }
   }
 }
+
+.content-section--blue {
+  .info-box {
+    border-color: govuk-colour("blue");
+  }
+
+  .info-box__corner {
+    background: govuk-colour("blue");
+  }
+}

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -21,7 +21,6 @@
 
 // Remove margin from the last element
 @mixin remove-last-child-margin {
-
   p:last-child,
   ul:last-child,
   ol:last-child {
@@ -39,15 +38,19 @@
   background: $colour;
 }
 
-@mixin left-bordered-block($border-colour,
-  $background-colour: govuk-colour("white")) {
+@mixin left-bordered-block(
+  $border-colour,
+  $background-colour: govuk-colour("white")
+) {
   @include block;
   border-left: 10px solid $border-colour;
   background: $background-colour;
 }
 
-@mixin emphatic-block($background-colour,
-  $foreground-colour: govuk-colour("white")) {
+@mixin emphatic-block(
+  $background-colour,
+  $foreground-colour: govuk-colour("white")
+) {
   @include coloured-block($background-colour);
   padding: 2em 0;
   text-align: center;
@@ -111,7 +114,6 @@
   width: 75px;
   height: auto;
 }
-
 
 .dfe-content-page--header {
   background-color: #347ca9;
@@ -178,14 +180,6 @@
   text-decoration: none;
 }
 
-.border-top-blue {
-  border-top: 8px solid govuk-colour("blue");
-}
-
-.bg-blue {
-  background: govuk-colour("blue");
-}
-
 .govuk-button {
   background-color: #003a69;
   color: #ffffff;
@@ -195,12 +189,12 @@
 }
 
 .govuk-button:hover {
-  background-color: #1D70B8;
+  background-color: #1d70b8;
 }
 
 .govuk-button:active {
-  background-color: #1D70B8;
-  border: 2px solid #FFDD00;
+  background-color: #1d70b8;
+  border: 2px solid #ffdd00;
 }
 
 .govuk-button:focus {
@@ -329,6 +323,12 @@ main {
 
   h2 {
     @include govuk-font($size: 24, $weight: bold);
+  }
+}
+
+.content-section--blue {
+  .govuk-inset-text {
+    border-color: govuk_colour("blue");
   }
 }
 

--- a/content/explore-all-resources/staff-wellbeing.html.erb
+++ b/content/explore-all-resources/staff-wellbeing.html.erb
@@ -9,12 +9,12 @@ layout: /explore_resources.html.erb
 
 <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
-    title: "Establishing a wellbeing committee",
-    href: "#",
+    title: "Establish a wellbeing committee",
+    href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
     tag:  "Wellbeing",
     details: {
-      resource_type: "Template",
-      reading_time: "4 minutes",
+      resource_type: "Example",
+      reading_time: "3 minutes",
       created_by: "Notre Dame High School"
     }
   )%>

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -88,9 +88,9 @@ title: Staff wellbeing
         <div class="govuk-grid-row dfe-width-container">
           <ul class="resource-card-group">
 
-            <%= render('/partials/resource_card.*', title: "Establishing a wellbeing committee" , href: "#" ,
+            <%= render('/partials/resource_card.*', title: "Establish a wellbeing committee" , href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
               body: "Learn how to set up a wellbeing committee." , tag: "Example",
-              details: { reading_time: "4 minutes", created_by: "Notre Dame High School" }) %>
+              details: { reading_time: "3 minutes", created_by: "Notre Dame High School" }) %>
 
             <%= render('/partials/resource_card.*', title: "Establishing a school workload group" , href: "#" ,
               body: "Learn how to set up a workload group." , tag: "Example" , details: { reading_time: "20 minutes" ,

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -23,7 +23,7 @@ title: Staff wellbeing
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container">
 
-    <div class="govuk-grid-row two-column-page">
+    <div class="govuk-grid-row two-column-page content-section--blue">
       <div class="govuk-grid-column-two-thirds">
 
         <div class="govuk-grid-row dfe-width-container">
@@ -31,8 +31,8 @@ title: Staff wellbeing
         </div>
 
         <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-          <div class="info-box border-top-blue">
-            <div class="info-box__corner bg-blue">
+          <div class="info-box">
+            <div class="info-box__corner">
               <img src="<%= @base_url %>/assets/images/i-icon.svg" alt="info icon">
             </div>
             <h2 class="govuk-heading-m">

--- a/content/staff-wellbeing/establish-a-wellbeing-committee.md
+++ b/content/staff-wellbeing/establish-a-wellbeing-committee.md
@@ -1,0 +1,126 @@
+---
+title: Establish a wellbeing committee
+layout: /markdown_resource.html.erb
+---
+
+# Establish a wellbeing committee
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Notre Dame High School
+
+**Location**: Norwich
+
+**Phase**: Secondary
+
+**Number of pupils**: 1400
+
+**Contact details**: Email Headteacher Neil Cully at <NCully@ndhs.org.uk>
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        We established a wellbeing committee who created a report on staff
+        wellbeing which was shared with governors and staff. The report included
+        quantitative data on staff absence rates which we try to benchmark
+        against national data. We use this, as well as qualitative data from our
+        staff wellbeing survey, to give an indication of staff wellbeing to
+        governors.
+      </p>
+      <p>
+        We review the committee terms of reference annually. They were
+        introduced to give clear purpose to the work of the committee so that it
+        did not simply become a ‘talking shop’.
+      </p>
+      <p>
+        All documentation, including minutes of meetings, is freely available to
+        all staff via our intranet. We make this transparent to increase
+        confidence, trust and accountability in what we seek to do.
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Neil Cully, Headteacher
+
+{inset-text}
+
+In the last 3 years we have directed our focus more specifically to identifying
+issues around staff wellbeing that we feel we have some control over and
+therefore can do something about.
+
+We created a committee to improve staff wellbeing. The committee is made up of
+volunteers who meet once every half term. Their focus has shifted towards
+creating the annual workload survey, analysing its results and formulating an
+action plan. They also consider issues raised by members of staff. We seek to
+make sure that the committee is representative of the different teams of staff
+within the school.
+
+{/inset-text}
+
+## 1. Choose who should be on the committee
+
+Create a committee comprised of leadership team members and representatives from
+all staff.
+
+Decide who will chair it.
+
+## 2. Agree what the committee should do
+
+The aim of the committee is to promote and ensure the wellbeing of all employees
+at the school. They could advise the leadership team on all matters relating to
+wellbeing within the school and report to governors termly.
+
+For example, the committee could:
+
+- distribute a survey to monitor wellbeing
+
+- identify issues that challenge the wellbeing of the staff
+
+- communicate issues to the leadership team and governors, suggesting ways to
+  resolve them
+
+- evaluate the impact of any intervention to resolve wellbeing issues
+
+- review the school’s wellbeing documentation at the start of each academic year
+
+- inform staff of wellbeing initiatives via the wellbeing notice board in the
+  staff room, the bulletin and staff meetings (when appropriate)
+
+## 3. Agree when and how the committee will meet
+
+The full committee could meet at least once per half term.
+
+A meeting schedule of these meetings and the membership of the committee could
+be regularly published to all staff.
+
+Additional meetings may be held for teachers and support staff committee
+members, also once per term, or by agreement between the chair and the staff
+representatives where circumstances warrant it.
+
+Notice of meetings could be advertised in advance so that staff can take any
+issues to their representative for discussion.
+
+## 4. Plan appropriate training
+
+The committee should ensure that its members receive appropriate training to
+undertake their duties.
+
+## 5. Review the committee
+
+The committee, and its terms of reference, will be reviewed at the first meeting
+of each autumn term and any proposed and agreed changes should go to the full
+governing body.

--- a/content/staff-wellbeing/establish-a-wellbeing-committee.md
+++ b/content/staff-wellbeing/establish-a-wellbeing-committee.md
@@ -1,6 +1,7 @@
 ---
 title: Establish a wellbeing committee
 layout: /markdown_resource.html.erb
+colour: blue
 ---
 
 # Establish a wellbeing committee

--- a/docs/adding-a-resource.md
+++ b/docs/adding-a-resource.md
@@ -6,7 +6,7 @@ resources.
 
 Useful links:
 
-- [Example resource file](docs/example-resource.md)
+- [Example resource file](example-resource.md)
 
 - [Example pull request](https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/pull/39) -
   this is an example pull request on Github, where a single resource has been
@@ -28,6 +28,23 @@ improve-workload-and-wellbeing-for-school-staff.education.gov.uk/**staff-wellbei
 
 Using the code in `example-resource.md` as a guide, copy the Markdown for your
 resource into your new file.
+
+All resources default to a purple colour scheme. If your resource uses a
+different colour scheme, you need to state it at the top of the file:
+
+```
+---
+title: TITLE
+layout: /markdown_resource.html.erb
+colour: blue
+---
+```
+
+Possible colours (other than the default purple) are:
+
+- `pink`
+- `green`
+- `blue`
 
 ## 3. Add your resource HTML 🎨
 

--- a/layouts/markdown_resource.html.erb
+++ b/layouts/markdown_resource.html.erb
@@ -1,6 +1,6 @@
 <% wrapped_content=capture do %>
   <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row govuk-width-container dfe-width-container markdown-page two-column-page">
+    <div class="govuk-grid-row govuk-width-container dfe-width-container markdown-page <%= @item[:colour] ? 'content-section--' + @item[:colour] : nil %> two-column-page">
       <div class="govuk-grid-column-two-thirds">
         <%= yield %>
         <h2 class="govuk-heading-m">Share this resource</h2>


### PR DESCRIPTION
## Changes in this PR

- Adds 'Establish a wellbeing committee' resource
- Adds link to this resource
- Adds new front matter option `colour`.
  - This defaults to purple (all existing resources are purple) 
  - Give the value `blue` to change inset text colour and info box to blue

## Guidance to review

https://trello.com/c/Xd4jMGkr/312-create-the-first-wellbeing-individual-resource

- Check new resource looks ok and links work
- Check that there are no regressions for existing resources in terms of colour scheme

<img width="1552" alt="Screenshot 2024-02-15 at 15 50 58" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/ba5737d1-15c3-4a05-b919-323f5e46e603">
