### PR TITLE
Fixing our mailto links

### DIFF
--- a/lib/filters/base_url_filter.rb
+++ b/lib/filters/base_url_filter.rb
@@ -18,7 +18,7 @@ module Nanoc
           url = node[attr]
 
           # Prepend base_url to relative paths
-          node[attr] = "#{base_url}/#{url}" if url && !url.start_with?('http', '/')
+          node[attr] = "#{base_url}/#{url}" if url && !url.start_with?('http', '/', 'mailto')
         end
 
         doc.to_html


### PR DESCRIPTION
I realised the mailto links didn't work. This is because the filter to make them external only applied for links starting with http and /. But the email link begins with mailto.

I've added mailto to the filter.