### PR TITLE
Add google tag manager

### DIFF
--- a/layouts/base.html
+++ b/layouts/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+  <%= render '/partials/tag_manager_head.*' %>
   <%= render '/partials/analytics.*' %>
   <meta charset="utf-8">
   <title>
@@ -14,6 +15,8 @@
 
 <body class="govuk-template__body js-enabled">
   <%= render '/partials/cookies_banner.*' %>
+
+  <%= render '/partials/tag_manager_body.*' %>
 
   <header class="dfe-header" role="banner">
     <div class="dfe-width-container dfe-header__container">

--- a/layouts/partials/tag_manager_body.html.erb
+++ b/layouts/partials/tag_manager_body.html.erb
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MFJXR544"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->

--- a/layouts/partials/tag_manager_head.html.erb
+++ b/layouts/partials/tag_manager_head.html.erb
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-MFJXR544');</script>
+  <!-- End Google Tag Manager -->


### PR DESCRIPTION
Card: [Set up consent mode](https://trello.com/c/4wGRCdBZ)

We have created the "Consent Status" Data Layer Variable in [Google Tag Manager](https://tagmanager.google.com/?utm_campaign=SuiteHeader&utm_source=UniversalPicker&utm_medium=getStarted#/container/accounts/6218708721/containers/178350106/workspaces/2/variables) (GTM).


We tested in [GTM](https://tagassistant.google.com/#/?source=TAG_MANAGER&id=GTM-MFJXR544&gtm_auth=v6h5KWgFamt_cahYRuhUYw&gtm_preview=env-4&cb=2581910948753181) using the preview [app](https://deploy-preview-61--iwwss-review.netlify.app/main/).

<img width="1823" alt="image" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/85567720/329cbda4-2944-4720-9da0-0f08ed982cab">


## Guidance to review

Check that you can access [Google Tag Manager](https://tagmanager.google.com/?utm_campaign=SuiteHeader&utm_source=UniversalPicker&utm_medium=getStarted#/container/accounts/6218708721/containers/178350106/workspaces/2/variables)