### PR TITLE
Update html of download boxes on feedback and marking resources

### DIFF
--- a/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
@@ -37,36 +37,34 @@ title: Review and streamline communications
         </div>
       </div>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <div class="govuk-grid-row dfe-width-container">
-          <div class="govuk-grid-column-full">
-            <div class="info-box">
-              <div class="info-box__corner">
-                <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+      <div class="govuk-grid-row dfe-width-container">
+        <div class="govuk-grid-column-full">
+          <div class="info-box">
+            <div class="info-box__corner">
+              <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+            </div>
+            <h2 class="govuk-heading-m">
+              Download the presentation
+            </h2>
+            <div class="govuk-grid-row info-box__download-content">
+              <div class="govuk-grid-column-one-half">
+                <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
               </div>
-              <h2 class="govuk-heading-m">
-                Download the presentation
-              </h2>
-              <div class="govuk-grid-row info-box__download-content">
-                <div class="govuk-grid-column-one-half">
-                  <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
-                </div>
-                <div class="govuk-grid-column-one-half">
-                  <p class="govuk-body-s">
-                    <strong>Presentation length:</strong> 1 hour
-                  </p>
-                  <p class="govuk-body-s">
-                    <strong>Resource type:</strong> Presentation
-                  </p>
-                  <p class="govuk-body-s">
-                    <strong>File type:</strong> OpenDocument Presentation, 198KB, 6 pages
-                  </p>
-                  <p>
-                    <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
-                      Download
-                    </a>
-                  </p>
-                </div>
+              <div class="govuk-grid-column-one-half">
+                <p class="govuk-body-s">
+                  <strong>Presentation length:</strong> 1 hour
+                </p>
+                <p class="govuk-body-s">
+                  <strong>Resource type:</strong> Presentation
+                </p>
+                <p class="govuk-body-s">
+                  <strong>File type:</strong> OpenDocument Presentation, 198KB, 6 pages
+                </p>
+                <p>
+                  <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
+                    Download
+                  </a>
+                </p>
               </div>
             </div>
           </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
@@ -12,7 +12,8 @@ title: Review and streamline feedback and marking
         </div>
         <div class="dfe-width-container govuk-grid-row">
           <p>
-            Use this presentation in a staff meeting or INSET day to review and streamline your feedback and marking processes. 
+            Use this presentation in a staff meeting or INSET day to review and
+            streamline your feedback and marking processes.
           </p>
           <p>
             The presentation includes:
@@ -26,54 +27,50 @@ title: Review and streamline feedback and marking
         </div>
       </div>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <ul class="resource-card-group govuk-!-margin-top-8 govuk-!-margin-bottom-0">
-
-          <div class="govuk-grid-row dfe-width-container">
-            <div class="govuk-grid-column-full">
-              <div class="info-box govuk-!-margin-top-0 govuk-!-margin-bottom-0">
-                <div class="info-box__corner">
-                  <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
-                </div>
-                <h2 class="govuk-heading-m">
-                  Download the presentation
-                </h2>
-                <div class="govuk-grid-row" style="align-items: center;">
-                  <div class="govuk-grid-column-one-half">
-                    <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image"
-                      class="dfe-file-preview-image">
-                  </div>
-                  <div class="govuk-grid-column-one-half">
-                    <div class="info-box__content">
-                      <p class="govuk-body-s govuk-!-margin-bottom-6">
-                        <strong>Presentation length:</strong> 1 hour and 15 minutes
-                      </p>
-                      <p class="govuk-body-s govuk-!-margin-bottom-6">
-                        <strong>Resource type:</strong> Presentation
-                      </p>
-                      <p class="govuk-body-s govuk-!-margin-bottom-6">
-                        <strong>File type:</strong> OpenDocument Presentation, 171KB, 7 pages
-                      </p>
-                      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold"
-                        href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
-                        Download
-                      </a>
-                    </div>
-                  </div>
+      <div class="govuk-grid-row dfe-width-container">
+        <div class="govuk-grid-column-full">
+          <div class="info-box">
+            <div class="info-box__corner">
+              <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+            </div>
+            <h2 class="govuk-heading-m">
+              Download the presentation
+            </h2>
+            <div class="govuk-grid-row info-box__download-content">
+              <div class="govuk-grid-column-one-half">
+                <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+              </div>
+              <div class="govuk-grid-column-one-half">
+                <div class="info-box__content">
+                  <p class="govuk-body-s">
+                    <strong>Presentation length:</strong> 1 hour and 15 minutes
+                  </p>
+                  <p class="govuk-body-s">
+                    <strong>Resource type:</strong> Presentation
+                  </p>
+                  <p class="govuk-body-s">
+                    <strong>File type:</strong> OpenDocument Presentation, 171KB, 7 pages
+                  </p>
+                  <p>
+                    <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
+                      Download
+                    </a>
+                  </p>
                 </div>
               </div>
             </div>
           </div>
-        </ul>
+        </div>
       </div>
 
       <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
           Audience
         </h2>
 
         <p>
-          This resource has been provided to support senior leadership teams to run a session with the whole school, teams or departments.   
+          This resource has been provided to support senior leadership teams to
+          run a session with the whole school, teams or departments.
         </p>
       </div>
 
@@ -83,8 +80,9 @@ title: Review and streamline feedback and marking
         </h2>
 
         <p>
-          The presentation should take 1 hour and 15 minutes. You should also allocate time for the facilitator to prepare the
-          session for use in your school.
+          The presentation should take 1 hour and 15 minutes. You should also
+          allocate time for the facilitator to prepare the session for use in
+          your school.
         </p>
       </div>
 
@@ -94,21 +92,30 @@ title: Review and streamline feedback and marking
         </h2>
 
         <p>
-          Depending on the situation in your school, you might wish to use this workshop as a starting point to initiate further exploration. You can also use it to prepare for the workshop with activities beforehand.        </p>
+          Depending on the situation in your school, you might wish to use this
+          workshop as a starting point to initiate further exploration. You can
+          also use it to prepare for the workshop with activities beforehand.
+        </p>
         <p>
           This could include your senior leadership team discussing: 
-            <ul>
-                <li>to what extent teachers follow your existing policy – and how you know?</li>
-                <li>can you clearly articulate what you expect from teachers – and is it reasonable?</li>
-                <li>do you have evidence to support the practices in your current policy?</li>
-                <li>how does your policy compare with examples from other schools?</li>
-            </ul>
+          <ul>
+            <li>to what extent teachers follow your existing policy – and how you know?</li>
+            <li>can you clearly articulate what you expect from teachers – and is it reasonable?</li>
+            <li>do you have evidence to support the practices in your current policy?</li>
+            <li>how does your policy compare with examples from other schools?</li>
+          </ul>
         </p>
         <p>
-          Senior leadership teams are likely to want to oversee the process. However they may want to consider if another staff member could facilitate the session and lead on follow-up, for example, a head of department. Alternatively, you might want to consider asking an independent person to facilitate the workshop, to free up time to take part. 
+          Senior leadership teams are likely to want to oversee the process.
+          However they may want to consider if another staff member could
+          facilitate the session and lead on follow-up, for example, a head of
+          department. Alternatively, you might want to consider asking an
+          independent person to facilitate the workshop, to free up time to take
+          part.
         </p>
         <p>
-          Provide a supportive environment for open and honest professional dialogue.  
+          Provide a supportive environment for open and honest professional
+          dialogue.
         </p>
       </div>
 
@@ -118,10 +125,10 @@ title: Review and streamline feedback and marking
         </h2>
 
         <ul class="resource-card-group">
-            <%= render('/partials/resource_card.*', title: "Impact graph" ,
-              href: "#{@base_url}/assets/files/Impact graph.odt" ,
-              body: "A template to help you prioritise what to address first." , tag: "Template" , download_link: true )
-              %>
+          <%= render('/partials/resource_card.*', title: "Impact graph",
+            href: "#{@base_url}/assets/files/Impact graph.odt",
+            body: "A template to help you prioritise what to address first.",
+            tag: "Template", download_link: true) %>
         </ul>
       </div>
     </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
@@ -31,12 +31,13 @@ layout: /markdown_resource.html.erb
         Impact and outcomes
       </h2>
       <p>
-         Using the impact matrix to review marking practices at the City of Norwich School has meant that: 
+         Using the impact matrix to review marking practices at the City of
+         Norwich School has meant that:
         <ul>
-          <li>homework activities have been simplified and marking criteria removed</li> 
+          <li>homework activities have been simplified and marking criteria removed</li>
           <li>mid-unit tests became shorter and more positively structured</li>
-          <li>tasks became much easier to mark and celebrate</li> 
-       </ul> 
+          <li>tasks became much easier to mark and celebrate</li>
+       </ul>
       </p>
     </div>
   </div>
@@ -46,47 +47,51 @@ layout: /markdown_resource.html.erb
 
 {inset-text}
 
-We developed a simple department activity to help prioritise and streamline marking practice, whilst maintaining the quality of marking that makes it meaningful and motivating. It was clear that our staff were not coping with marking workloads and as consequence books were not marked effectively. The Head of Science, Head of School and Assistant Headteacher sat together and worked to create and complete the impact matrix. 
+We developed a simple department activity to help prioritise and streamline
+marking practice, whilst maintaining the quality of marking that makes it
+meaningful and motivating. It was clear that our staff were not coping with
+marking workloads and as consequence books were not marked effectively. The Head
+of Science, Head of School and Assistant Headteacher sat together and worked to
+create and complete the impact matrix.
 
 {/inset-text}
 
 <div class="dfe-width-container govuk-grid-row">
-  <ul class="resource-card-group govuk-!-margin-top-8 govuk-!-margin-bottom-0">
-    <div class="govuk-grid-row dfe-width-container">
-      <div class="govuk-grid-column-full">
-        <div class="info-box govuk-!-margin-top-0 govuk-!-margin-bottom-0">
-          <div class="info-box__corner">
-            <img src="/assets/images/download-icon.svg" alt="Download icon">
-          </div>
-          <h2 class="govuk-heading-m">
-            Download the impact matrix
-          </h2>
-          <div class="govuk-grid-row" style="align-items: center;">
-            <div class="govuk-grid-column-one-half">
-              <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image"
-                class="dfe-file-preview-image">
-            </div>
-            <div class="govuk-grid-column-one-half">
-              <div class="info-box__content">
-                <p class="govuk-body-s govuk-!-margin-bottom-6">
-                  <strong>Resource type:</strong> Template
-                </p>
-                <p class="govuk-body-s govuk-!-margin-bottom-6">
-                  <strong>File type:</strong> Document, 6KB, 1 page
-                </p>
-                <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold"
-                  href="<%= @base_url %>/assets/files/Impact matrix.odt">
-                  Download
-                </a>
-              </div>
-            </div>
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Download the impact matrix
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="info-box__content">
+            <p class="govuk-body-s">
+              <strong>Resource type:</strong> Template
+            </p>
+            <p class="govuk-body-s">
+              <strong>File type:</strong> Document, 6KB, 1 page
+            </p>
+            <a class="govuk-link govuk-link--no-visited-state"
+              href="<%= @base_url %>/assets/files/Impact matrix.odt">
+              Download
+            </a>
           </div>
         </div>
       </div>
     </div>
-  </ul>
+  </div>
 </div>
 
-## Using the impact matrix to review marking 
+## Using the impact matrix to review marking
 
-The impact matrix can be downloaded and used to review your own practice or approach to marking. It can be adapted as necessary for other tasks such as planning, communications or data management. You can read more about The City of Norwich School’s approach to tackling workload in their [blog](https://teaching.blog.gov.uk/2018/01/19/using-curriculum-area-development-time-to-reduce-teacher-workload/). 
+The impact matrix can be downloaded and used to review your own practice or
+approach to marking. It can be adapted as necessary for other tasks such as
+planning, communications or data management. You can read more about The City of
+Norwich School’s approach to tackling workload in their
+[blog](https://teaching.blog.gov.uk/2018/01/19/using-curriculum-area-development-time-to-reduce-teacher-workload/).

--- a/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
@@ -12,69 +12,67 @@ Use this survey template to gather information from school staff
 about their workload. You can address issues you identify with
 resources from the workload reduction toolkit.
 
-<div class="govuk-grid-row govuk-!-padding-bottom-6">
-  <div class="govuk-grid-row dfe-width-container">
-    <div class="govuk-grid-column-full">
-      <div class="info-box">
-        <div class="info-box__corner">
-          <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+      </div>
+      <p>
+        The survey can be edited to meet the needs of your setting and
+        you can add, change or remove questions if required. For
+        example, some parts of the survey may be more appropriate for
+        primary or secondary settings.
+      </p>
+      <h2 class="govuk-heading-m">
+        Use online versions of the survey
+      </h2>
+      <p>
+        You can duplicate and adapt one of these online versions of the
+        staff workload survey:
+      </p>
+      <p>
+        <ul>
+          <li>
+            <a
+              href="https://forms.office.com/Pages/ShareFormPage.aspx?id=yXfS-grGoU2187O4s0qC-cn26r-uTMpNqURSfi9lRcVUNEg1UTdMMllFRTM1SEVRRDJWQjE3RUU5VS4u&sharetoken=MJnNysyL44umvL8f97JA"
+              class="govuk-link">
+              Microsoft Forms - staff workload survey template
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLScrEp_mdZIYbEj404OFKMrRsSFmkFP2p_q_cfVy9wdkoTDtyw/viewform?pli=1"
+              class="govuk-link">
+              Google Forms - staff workload survey template
+            </a>
+          </li>
+        </ul>
+      </p>
+      <p>
+        Some schools find online surveys easier to share with staff than
+        a paper form because they collate the results automatically for
+        you.
+      </p>
+      <h2 class="govuk-heading-m">
+        Download the staff workload survey
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
         </div>
-        <p>
-          The survey can be edited to meet the needs of your setting and
-          you can add, change or remove questions if required. For
-          example, some parts of the survey may be more appropriate for
-          primary or secondary settings.
-        </p>
-        <h2 class="govuk-heading-m">
-          Use online versions of the survey
-        </h2>
-        <p>
-          You can duplicate and adapt one of these online versions of the
-          staff workload survey:
-        </p>
-        <p>
-          <ul>
-            <li>
-              <a
-                href="https://forms.office.com/Pages/ShareFormPage.aspx?id=yXfS-grGoU2187O4s0qC-cn26r-uTMpNqURSfi9lRcVUNEg1UTdMMllFRTM1SEVRRDJWQjE3RUU5VS4u&sharetoken=MJnNysyL44umvL8f97JA"
-                class="govuk-link">
-                Microsoft Forms - staff workload survey template
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://docs.google.com/forms/d/e/1FAIpQLScrEp_mdZIYbEj404OFKMrRsSFmkFP2p_q_cfVy9wdkoTDtyw/viewform?pli=1"
-                class="govuk-link">
-                Google Forms - staff workload survey template
-              </a>
-            </li>
-          </ul>
-        </p>
-        <p>
-          Some schools find online surveys easier to share with staff than
-          a paper form because they collate the results automatically for
-          you.
-        </p>
-        <h2 class="govuk-heading-m">
-          Download the staff workload survey
-        </h2>
-        <div class="govuk-grid-row info-box__download-content">
-          <div class="govuk-grid-column-one-half">
-            <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
-          </div>
-          <div class="govuk-grid-column-one-half">
-            <p class="govuk-body-s">
-              <strong>Resourced type:</strong> Template
-            </p>
-            <p class="govuk-body-s">
-              <strong>File type:</strong> Document, 70KB, 5 pages
-            </p>
-            <p>
-              <a class="govuk-link govuk-link--no-visited-state" href="#">
-                Download
-              </a>
-            </p>
-          </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body-s">
+            <strong>Resourced type:</strong> Template
+          </p>
+          <p class="govuk-body-s">
+            <strong>File type:</strong> Document, 70KB, 5 pages
+          </p>
+          <p>
+            <a class="govuk-link govuk-link--no-visited-state" href="#">
+              Download
+            </a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes in this PR

Quick updates to html of download boxes on feedback and marking resources to remove `<ul>` and tidy up some classes we don't need anymore.