### PR TITLE
Add evaluate section page with green styling

### DIFF
--- a/content/assets/css/_info-box.scss
+++ b/content/assets/css/_info-box.scss
@@ -61,3 +61,13 @@
     background: #d4357f;
   }
 }
+
+.content-section--green {
+  .info-box {
+    border-color: #279b91;
+  }
+
+  .info-box__corner {
+    background: #279b91;
+  }
+}

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -342,6 +342,12 @@ main {
   }
 }
 
+.content-section--green {
+  .govuk-inset-text {
+    border-color: #279b91;
+  }
+}
+
 .govuk-tag {
   background-color: govuk-colour("blue");
   color: govuk-colour("white");

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -54,7 +54,7 @@ title: Workload reduction toolkit
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="#">
+        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/evaluate-workload-issues">
           <p class="dfe-card-header dfe-card-header--green">Evaluate workload measures</p>
           <div class="dfe-card-body">
             <p class="govuk-body">Track and evaluate workload reduction measures</p>

--- a/content/workload-reduction-toolkit/evaluate-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/evaluate-workload-issues.html.erb
@@ -1,0 +1,91 @@
+---
+title: Evaluate workload issues
+---
+
+<div class="govuk-main-wrapper">
+  <div class="dfe-width-container govuk-grid-row two-column-page">
+    <div class="dfe-width-container govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <h1 class="govuk-heading-l">Evaluate workload issues</h1>
+        <p>
+          These resources help you track and evaluate the impact of your
+          workload reduction measures.
+        </p>
+        <p>
+          Some school leaders add workload reduction as a key priority in their
+          school improvement plans to monitor and evaluate progress.
+        </p>
+      </div>
+    </div>
+    
+    <div class="dfe-width-container govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <hr class="govuk-section-break--thick">
+
+        <div class="govuk-grid-row dfe-width-container content-section--green">
+          <div class="info-box">
+            <div class="info-box__corner">
+              <img src="/assets/images/i-icon.svg" alt="info icon">
+            </div>
+            <h2 class="govuk-heading-m">
+              How to use this section
+            </h2>
+            <p>
+              You can use and adapt these resources to help monitor the impact
+              of your workload reduction measures. Evaluation methods can
+              include:
+            </p>
+            <p>
+              <ul>
+                <li>conducting surveys with school staff, pupils, parents and carers</li>
+                <li>reviewing the results of pupils</li>
+                <li>trialling different teaching approaches with parallel classes</li>
+              </ul>
+            </p>
+            <p>
+              As a senior leadership team, you should use these resources to
+              provide regular feedback to school staff and governors.
+            </p>
+          </div>
+        </div>
+
+        <div class="dfe-width-container govuk-grid-row">
+          <h2 class="govuk-heading-m">
+            Tools to help evaluate workload reduction measures
+          </h2>
+
+          <ul class="resource-card-group">
+            <%= render('/partials/resource_card.*',
+              title: "Evaluate impact using a staff workload survey",
+              href: "TBC",
+              body: "Gather feedback from staff and teachers about your workload reduction measures.",
+              tag: "Template") %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Evaluate progress with staff",
+              href: "TBC",
+              body: "Show staff the actions you took to address workload issues and gather feedback.",
+              tag: "Template") %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Have structured conversations with staff to evaluate outcomes",
+              href: "TBC",
+              body: "Talk to staff and teachers about their biggest workload issues.",
+              tag: "Template") %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Update your workload action plan",
+              href: "TBC",
+              body: "Evaluate the actions you took to reduce workload in your school.",
+              tag: "Template") %>
+          </ul>
+        </div>
+      </div>
+
+      <div class="govuk-grid-column-one-third">
+        <hr class="govuk-section-break--blue govuk-section-break--thick">
+        <%= render '/partials/feedback.*' %>
+      </div> 
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Changes in this PR

- Adds the Evaluate section page
- Adds `--green` classes for info box and inset text which will also be used for the individual resources
- Links the page from Workload reduction toolkit

## Guidance to review

https://trello.com/c/AESX0mEV/339-create-evaluate-section-page

- Links to individual resources TBC as not built yet

<img width="1552" alt="Screenshot 2024-02-27 at 14 09 02" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/591ebf6c-61e5-4cc7-85f4-caedc2b5e8bd">
