### PR TITLE
[xxx] Refactor markdown layouts

### DIFF
--- a/Rules
+++ b/Rules
@@ -31,7 +31,7 @@ compile '/**/*.md' do
   next if item.identifier.without_ext =~ %r{^/assets/css/}
 
   filter :govuk_markdown
-  layout item.fetch(:layout, '/markdown_layout.*')
+  layout item.fetch(:layout, '/markdown_resource.*')
 
   if item.identifier =~ '**/index.*'
     write item.identifier.to_s

--- a/content/staff-wellbeing/establish-a-wellbeing-committee.md
+++ b/content/staff-wellbeing/establish-a-wellbeing-committee.md
@@ -1,6 +1,5 @@
 ---
 title: Establish a wellbeing committee
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/supporting-staff-mental-health.md
+++ b/content/staff-wellbeing/supporting-staff-mental-health.md
@@ -1,5 +1,6 @@
 ---
 title: Supporting staff mental health in schools
+layout: /markdown_layout.html.erb
 ---
 
 # Supporting staff mental health in schools

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Parental communications policy
-layout: /markdown_resource.html.erb
 ---
 
 # Parental communications policy

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/school-email-protocol.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/school-email-protocol.md
@@ -1,6 +1,5 @@
 ---
 title: School email protocol
-layout: /markdown_resource.html.erb
 ---
 
 # School email protocol

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/streamline-internal-school-communications.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/streamline-internal-school-communications.md
@@ -1,6 +1,5 @@
 ---
 title: Streamline internal school communications
-layout: /markdown_resource.html.erb
 ---
 
 # Streamline internal school communications
@@ -40,14 +39,10 @@ layout: /markdown_resource.html.erb
       </p>
       <ul>
         <li>efficiency</li>
-        
         <li>less time wasted</li>
-      
         <li>being kept informed</li>
-      
         <li>sufficient notice of changes</li>
       </ul>
-
       <p>
         There was no change in teacher perception on responding to emails outside of work.
       </p>

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/switch-to-online-parents-evenings.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/switch-to-online-parents-evenings.md
@@ -1,6 +1,5 @@
 ---
 title: Switch to online parents' evenings
-layout: /markdown_resource.html.erb
 ---
 
 # Switch to online parents’ evenings

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/change-lesson-observations-to-class-visits.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/change-lesson-observations-to-class-visits.md
@@ -1,6 +1,5 @@
 ---
 title: Change lesson observations to class visits
-layout: /markdown_resource.html.erb
 ---
 
 # Change lesson observations to class visits

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/develop-a-culture-of-support-and-staff-development.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/develop-a-culture-of-support-and-staff-development.md
@@ -1,6 +1,5 @@
 ---
 title: Develop a culture of support and staff development
-layout: /markdown_resource.html.erb
 ---
 
 # Develop a culture of support and staff development

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/try-ideas-to-manage-planning.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/try-ideas-to-manage-planning.md
@@ -1,6 +1,5 @@
 ---
 title: Try ideas to manage planning and curriculum workload
-layout: /markdown_resource.html.erb
 ---
 
 # Try ideas to manage planning and curriculum workload

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/use-time-effectively.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/use-time-effectively.md
@@ -1,6 +1,5 @@
 ---
 title: Use time effectively and work together when planning your curriculum
-layout: /markdown_resource.html.erb
 ---
 
 # Use time effectively and work together when planning your curriculum

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/cut-down-your-marking-workload.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/cut-down-your-marking-workload.md
@@ -1,6 +1,5 @@
 ---
 title: Cut down your marking workload
-layout: /markdown_resource.html.erb
 ---
 
 # Cut down your marking workload

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-and-avoid-marking-in-primary-schools.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-and-avoid-marking-in-primary-schools.md
@@ -1,6 +1,5 @@
 ---
 title: Give feedback and avoid marking in primary schools
-layout: /markdown_resource.html.erb
 ---
 
 # Give feedback and avoid marking in primary schools

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-effectively-without-creating-an-unmanageable-workload.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-effectively-without-creating-an-unmanageable-workload.md
@@ -1,6 +1,5 @@
 ---
 title: Give feedback effectively without creating an unmanageable workload
-layout: /markdown_resource.html.erb
 ---
 
 # Give feedback effectively without creating an unmanageable workload

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils.md
@@ -1,6 +1,5 @@
 ---
 title: Improve how you give feedback to primary pupils
-layout: /markdown_resource.html.erb
 ---
 
 # Improve how you give feedback to primary pupils

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
@@ -1,6 +1,5 @@
 ---
 title: Review marking practice with an impact matrix
-layout: /markdown_resource.html.erb
 ---
 
 # Review marking practice with an impact matrix

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/secondary-school-feedback-policy.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/secondary-school-feedback-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Secondary school feedback policy
-layout: /markdown_resource.html.erb
 ---
 
 # Secondary school feedback policy

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/try-ideas-to-manage-feedback-and-marking.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/try-ideas-to-manage-feedback-and-marking.md
@@ -1,6 +1,5 @@
 ---
 title: Try ideas to manage feedback and marking workload
-layout: /markdown_resource.html.erb
 ---
 
 # Try ideas to manage feedback and marking workload

--- a/content/workload-reduction-toolkit/how-the-toolkit-was-made.md
+++ b/content/workload-reduction-toolkit/how-the-toolkit-was-made.md
@@ -1,5 +1,6 @@
 ---
 title: How the toolkit was made and tested
+layout: /markdown_layout.html.erb
 ---
 
 # How the toolkit was made and tested

--- a/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
@@ -1,6 +1,5 @@
 ---
 title: Staff workload survey
-layout: /markdown_resource.html.erb
 colour: pink
 ---
 

--- a/docs/adding-a-resource.md
+++ b/docs/adding-a-resource.md
@@ -35,7 +35,6 @@ different colour scheme, you need to state it at the top of the file:
 ```
 ---
 title: TITLE
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 ```

--- a/docs/example-resource.md
+++ b/docs/example-resource.md
@@ -1,6 +1,5 @@
 ---
 title: INSERT-TITLE
-layout: /markdown_resource.html.erb
 ---
 
 # INSERT-TITLE


### PR DESCRIPTION
## Context

- We have lots and LOTS of markdown pages now, but only two of them use the `markdown_layout.html.erb` specified as default in the `Rules` file
- The vast majority are using the `markdown_resource.html.erb` layout which needs to be specified in each front matter

## Changes in this PR

- Make the `markdown_resource.html.erb` layout default. This makes sense for future development because more markdown resources are likely to be added by non-devs
- No visual changes.