### PR TITLE
Add wellbeing resources and links

### DIFF
--- a/content/explore-all-resources/staff-wellbeing.html.erb
+++ b/content/explore-all-resources/staff-wellbeing.html.erb
@@ -11,7 +11,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Create a school culture which improves wellbeing",
     href: "#{@base_url}/staff-wellbeing/create-a-school-culture-which-improves-wellbeing",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Case study",
       reading_time: "4 minutes",
@@ -22,7 +22,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Academy trust workload agreement",
     href: "#{@base_url}/staff-wellbeing/academy-trust-workload-agreement",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Example",
       reading_time: "2 minutes",
@@ -33,7 +33,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Staff wellbeing policy",
     href: "#{@base_url}/staff-wellbeing/staff-wellbeing-policy",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Example",
       reading_time: "6 minutes",
@@ -44,7 +44,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Staff wellbeing statement",
     href: "#{@base_url}/staff-wellbeing/staff-wellbeing-statement",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Example",
       reading_time: "3 minutes",
@@ -55,7 +55,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Establish a wellbeing committee",
     href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Example",
       reading_time: "3 minutes",
@@ -66,7 +66,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Establish a school workload group",
     href: "#{@base_url}/staff-wellbeing/establish-a-school-workload-group",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Example",
       reading_time: "3 minutes",
@@ -77,7 +77,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Communicate about wellbeing to improve staff retention",
     href: "#{@base_url}/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Example",
       reading_time: "3 minutes",
@@ -88,7 +88,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Protect staff time and improve wellbeing",
     href: "#{@base_url}/staff-wellbeing/",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Case study",
       reading_time: "2 minutes",
@@ -99,7 +99,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Try ideas to improve staff wellbeing",
     href: "#{@base_url}/staff-wellbeing/try-ideas-to-improve-staff-wellbeing",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Case study",
       reading_time: "2 minutes",
@@ -110,7 +110,7 @@ layout: /explore_resources.html.erb
   <%= render('/partials/explore_resource_card.*',
     title: "Make a list of everything you do to improve wellbeing",
     href: "#{@base_url}/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing",
-    tag:  "Wellbeing",
+    tag:  "Staff wellbeing",
     details: {
       resource_type: "Case study",
       reading_time: "3 minutes",

--- a/content/explore-all-resources/staff-wellbeing.html.erb
+++ b/content/explore-all-resources/staff-wellbeing.html.erb
@@ -19,7 +19,6 @@ layout: /explore_resources.html.erb
     }
   )%>
 
-<div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
     title: "Academy trust workload agreement",
     href: "#{@base_url}/staff-wellbeing/academy-trust-workload-agreement",
@@ -31,7 +30,6 @@ layout: /explore_resources.html.erb
     }
   )%>
 
-<div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
     title: "Staff wellbeing policy",
     href: "#{@base_url}/staff-wellbeing/staff-wellbeing-policy",
@@ -43,7 +41,6 @@ layout: /explore_resources.html.erb
     }
   )%>
 
-<div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
     title: "Staff wellbeing statement",
     href: "#{@base_url}/staff-wellbeing/staff-wellbeing-statement",
@@ -55,7 +52,6 @@ layout: /explore_resources.html.erb
     }
   )%>
 
-<div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
     title: "Establish a wellbeing committee",
     href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
@@ -67,7 +63,6 @@ layout: /explore_resources.html.erb
     }
   )%>  
 
-  <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
     title: "Establish a school workload group",
     href: "#{@base_url}/staff-wellbeing/establish-a-school-workload-group",
@@ -79,7 +74,6 @@ layout: /explore_resources.html.erb
     }
   )%>
 
-  <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
     title: "Communicate about wellbeing to improve staff retention",
     href: "#{@base_url}/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention",
@@ -90,7 +84,7 @@ layout: /explore_resources.html.erb
       created_by: "Bedford Academy (Secondary)"
     }
   )%>
-<div class="explore-resource-card-group">
+
   <%= render('/partials/explore_resource_card.*',
     title: "Protect staff time and improve wellbeing",
     href: "#{@base_url}/staff-wellbeing/",
@@ -101,7 +95,7 @@ layout: /explore_resources.html.erb
       created_by: "West Meon CofE Primary School"
     }
   )%>
-<div class="explore-resource-card-group">
+
   <%= render('/partials/explore_resource_card.*',
     title: "Try ideas to improve staff wellbeing",
     href: "#{@base_url}/staff-wellbeing/try-ideas-to-improve-staff-wellbeing",
@@ -112,7 +106,7 @@ layout: /explore_resources.html.erb
       created_by: "King Charles I Secondary School"
     }
   )%>
-  <div class="explore-resource-card-group">
+
   <%= render('/partials/explore_resource_card.*',
     title: "Make a list of everything you do to improve wellbeing",
     href: "#{@base_url}/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing",

--- a/content/explore-all-resources/staff-wellbeing.html.erb
+++ b/content/explore-all-resources/staff-wellbeing.html.erb
@@ -9,6 +9,54 @@ layout: /explore_resources.html.erb
 
 <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
+    title: "Create a school culture which improves wellbeing",
+    href: "#{@base_url}/staff-wellbeing/create-a-school-culture-which-improves-wellbeing",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Case study",
+      reading_time: "4 minutes",
+      created_by: "Kensington Primary School"
+    }
+  )%>
+
+<div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
+    title: "Academy trust workload agreement",
+    href: "#{@base_url}/staff-wellbeing/academy-trust-workload-agreement",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Example",
+      reading_time: "2 minutes",
+      created_by: "Ascent Multi-Academy trust"
+    }
+  )%>
+
+<div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
+    title: "Staff wellbeing policy",
+    href: "#{@base_url}/staff-wellbeing/staff-wellbeing-policy",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Example",
+      reading_time: "6 minutes",
+      created_by: "The Pingle Academy (Secondary)"
+    }
+  )%>
+
+<div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
+    title: "Staff wellbeing statement",
+    href: "#{@base_url}/staff-wellbeing/staff-wellbeing-statement",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Example",
+      reading_time: "3 minutes",
+      created_by: "St. Peter's School (Secondary)"
+    }
+  )%>
+
+<div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
     title: "Establish a wellbeing committee",
     href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
     tag:  "Wellbeing",
@@ -17,82 +65,62 @@ layout: /explore_resources.html.erb
       reading_time: "3 minutes",
       created_by: "Notre Dame High School"
     }
-  )%>
+  )%>  
 
+  <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
-    title: "Establishing a school workload group",
-    href: "#",
+    title: "Establish a school workload group",
+    href: "#{@base_url}/staff-wellbeing/establish-a-school-workload-group",
     tag:  "Wellbeing",
     details: {
       resource_type: "Example",
-      reading_time: "20 minutes",
-      created_by: "Baylis Court School"
+      reading_time: "3 minutes",
+      created_by: "Baylis Court School (Secondary)"
     }
   )%>
 
+  <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
-    title: "21 things we did to improve staff wellbeing",
-    href: "#",
+    title: "Communicate about wellbeing to improve staff retention",
+    href: "#{@base_url}/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Example",
+      reading_time: "3 minutes",
+      created_by: "Bedford Academy (Secondary)"
+    }
+  )%>
+<div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
+    title: "Protect staff time and improve wellbeing",
+    href: "#{@base_url}/staff-wellbeing/",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Case study",
+      reading_time: "2 minutes",
+      created_by: "West Meon CofE Primary School"
+    }
+  )%>
+<div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
+    title: "Try ideas to improve staff wellbeing",
+    href: "#{@base_url}/staff-wellbeing/try-ideas-to-improve-staff-wellbeing",
+    tag:  "Wellbeing",
+    details: {
+      resource_type: "Case study",
+      reading_time: "2 minutes",
+      created_by: "King Charles I Secondary School"
+    }
+  )%>
+  <div class="explore-resource-card-group">
+  <%= render('/partials/explore_resource_card.*',
+    title: "Make a list of everything you do to improve wellbeing",
+    href: "#{@base_url}/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing",
     tag:  "Wellbeing",
     details: {
       resource_type: "Case study",
       reading_time: "3 minutes",
-      created_by: "King Charles I Secondary School"
+      created_by: "Barr Beacon School (Secondary)"
     }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Prioritise wellbeing",
-    href: "#",
-    tag:  "Wellbeing",
-    details: {
-      resource_type: "Case study",
-      reading_time: "11 minutes",
-      created_by: "Bedford Academy"
-    }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Whole school approach to wellbeing",
-    href: "#",
-    tag:  "Wellbeing",
-    details: {
-      resource_type: "Case study",
-      reading_time: "7 minutes",
-      created_by: "Barr Beacon School"
-    }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Academy trust workload agreement",
-    href: "#",
-    tag:  "Wellbeing",
-    details: {
-      resource_type: "Example",
-      reading_time: "6 minutes",
-      created_by: "Academy Multi Academy Trust"
-    }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Wellbeing and Workload Charter",
-    href: "#",
-    tag:  "Wellbeing",
-    details: {
-      resource_type: "Example",
-      reading_time: "11 minutes",
-      created_by: "Bedford Academy"
-    }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Wellbeing policy",
-    href: "#",
-    tag:  "Wellbeing",
-    details: {
-      resource_type: "Example",
-      reading_time: "9 minutes",
-      created_by: "The Pingle Academy"
-    }
-  )%>
+  )%>  
 </div>

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -49,12 +49,8 @@ title: Staff wellbeing
           </div>
         </div>
 
-        <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-          <h2 class="govuk-heading-m">Resources to support staff wellbeing</h2>
-        </div>
-
         <div class="govuk-grid-row dfe-width-container  govuk-!-padding-bottom-0">
-          <h2 class="govuk-heading-s">Set a wellbeing vision</h2>
+          <h2 class="govuk-heading-m">Resources to help set a wellbeing vision</h2>
         </div>
 
         <div class="govuk-grid-row dfe-width-container govuk-!-margin-bottom-3">
@@ -78,7 +74,7 @@ title: Staff wellbeing
         </div>
 
         <div class="govuk-grid-row dfe-width-container govuk-!-padding-top-6 govuk-!-padding-bottom-0">
-          <h2 class="govuk-heading-s">Decide who will drive it forward</h2>
+          <h2 class="govuk-heading-m">Resources to support communications on wellbeing</h2>
         </div>
 
         <div class="govuk-grid-row dfe-width-container">
@@ -100,7 +96,7 @@ title: Staff wellbeing
         </div>
 
         <div class="govuk-grid-row dfe-width-container govuk-!-padding-top-6 govuk-!-padding-bottom-0">
-          <h2 class="govuk-heading-s">Take action</h2>
+          <h2 class="govuk-heading-m">Resources to help you take action</h2>
         </div>
 
         <div class="govuk-grid-row dfe-width-container">

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -59,24 +59,20 @@ title: Staff wellbeing
 
         <div class="govuk-grid-row dfe-width-container govuk-!-margin-bottom-3">
           <ul class="resource-card-group">
-            <%= render('/partials/resource_card.*', title: "Workload and wellbeing action plan" , href: "#" ,
-              body: "Create an action plan to focus on staff wellbeing." , tag: "Example",
-              details: { reading_time: "4 minutes" , created_by: "Notre Dame High School" }) %>
+            <%= render('/partials/resource_card.*', title: "Create a school culture which improves wellbeing" , href: "#{@base_url}/staff-wellbeing/create-a-school-culture-which-improves-wellbeing" ,
+              body: "Learn how to develop a school culture of wellbeing and workload improvement." , tag: "Case study",
+              details: { reading_time: "4 minutes" , created_by: "Kensington Primary School" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Academy trust workload agreement" , href: "#" ,
+            <%= render('/partials/resource_card.*', title: "Academy trust workload agreement" , href: "#{@base_url}/staff-wellbeing/academy-trust-workload-agreement" ,
               body: "Share what teachers can expect in terms of workload, professional development, pay and rewards.",
-              tag: "Example" , details: { reading_time: "6 minutes" , created_by: "Ascent Multi Academy trust (MAT)" }) %>
+              tag: "Example" , details: { reading_time: "2 minutes" , created_by: "Ascent Multi-Academy trust" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Wellbeing and Workload Charter" , href: "#" ,
-              body: "Read an example wellbeing and workload charter." , tag: "Example" , details: {
-              reading_time: "11 minutes" , created_by: "Bedford Academy (Secondary)" }) %>
-
-            <%= render('/partials/resource_card.*', title: "See an example staff wellbeing policy" , href: "#" ,
+            <%= render('/partials/resource_card.*', title: "Staff wellbeing policy" , href: "#{@base_url}/staff-wellbeing/staff-wellbeing-policy" ,
                 body: "Read a staff wellbeing policy that reflects a whole school approach to wellbeing." ,
-                tag: "Example" , details: { reading_time: "9 minutes" , created_by: "The Pingle Academy (Secondary)" }) %>
+                tag: "Example" , details: { reading_time: "6 minutes" , created_by: "The Pingle Academy (Secondary)" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Secondary school staff wellbeing statement" ,
-                href: "#" , body: "Read a wellbeing statement developed to effectively support school staff." ,
+            <%= render('/partials/resource_card.*', title: "Staff wellbeing statement" ,
+                href: "#{@base_url}/staff-wellbeing/staff-wellbeing-statement" , body: "Read a wellbeing statement developed to support school staff effectively." ,
                 tag: "Example" , details: { reading_time: "3 minutes", created_by: "St. Peter's School (Secondary)" }) %>
           </ul>
         </div>
@@ -92,17 +88,13 @@ title: Staff wellbeing
               body: "Learn how to set up a wellbeing committee." , tag: "Example",
               details: { reading_time: "3 minutes", created_by: "Notre Dame High School" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Establishing a school workload group" , href: "#" ,
-              body: "Learn how to set up a workload group." , tag: "Example" , details: { reading_time: "20 minutes" ,
+            <%= render('/partials/resource_card.*', title: "Establish a school workload group" , href: "#{@base_url}/staff-wellbeing/establish-a-school-workload-group" ,
+              body: "Learn how to set up a workload group." , tag: "Example" , details: { reading_time: "3 minutes" ,
               created_by: "Baylis Court School (Secondary)" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Prioritising wellbeing to improve staff retention" ,
-              href: "#" , body: "Learn how prioritising wellbeing impacted staff retention." , tag: "Example" ,
-              details: { reading_time: "11 minutes" , created_by: "Bedford Academy (Secondary)" }) %>
-
-            <%= render('/partials/resource_card.*', title: "Prioritising wellbeing to improve staff retention" ,
-              href: "#" , body: "Learn how prioritising wellbeing impacted staff retention." , tag: "Example" ,
-              details: { reading_time: "11 minutes" , created_by: "Bedford Academy (Secondary)" }) %>
+            <%= render('/partials/resource_card.*', title: "Communicate about wellbeing to improve staff retention" ,
+              href: "#{@base_url}/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention" , body: "Learn how communication improved staff retention." , tag: "Case study" ,
+              details: { reading_time: "3 minutes" , created_by: "Bedford Academy (Secondary)" }) %>
 
           </ul>
         </div>
@@ -114,19 +106,17 @@ title: Staff wellbeing
         <div class="govuk-grid-row dfe-width-container">
           <ul class="resource-card-group">
 
-            <%= render('/partials/resource_card.*',
-              title: "21 things we did to improve staff wellbeing" ,
-              href: "#" ,
-              body: "Read advice and tips on improving staff wellbeing." ,
-              tag: "Example" ,
-              details: { reading_time: "3 minutes" , created_by: "King Charles I Secondary School" }) %>
+            <%= render('/partials/resource_card.*', title: "Protect staff time and improve wellbeing" , href: "#{@base_url}/staff-wellbeing/protect-staff-time-and-improvement-wellbeing" ,
+              body: "Read tips on using time effectively to improve wellbeing." , tag: "Case study" , details: {
+              reading_time: "2 minutes" , created_by: "West Meon CofE Primary School" }) %>
 
-            <%= render('/partials/resource_card.*',
-              title: "Whole school approach to wellbeing",
-              href: "#" ,
-              body: "Read advice and tips on improving staff wellbeing.",
-              tag: "Example",
-              details: { reading_time: "7 minutes" , created_by: "Barr Beacon School (Secondary)" }) %>
+           <%= render('/partials/resource_card.*', title: "Try ideas to improve staff wellbeing" , href: "#{@base_url}/staff-wellbeing/try-ideas-to-improve-staff-wellbeing" ,
+              body: "Read advice and tips on improving staff wellbeing." , tag: "Case study" , details: {
+              reading_time: "2 minutes" , created_by: "King Charles I Secondary School" }) %>
+
+           <%= render('/partials/resource_card.*', title: "Make a list of everything you do to improve wellbeing" , href: "#{@base_url}/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing" ,
+              body: "Read how a school reflects on everything they do to reduce workload and improve wellbeing." , tag: "Case study" , details: {
+              reading_time: "3 minutes" , created_by: "Barr Beacon School (Secondary)" }) %>
           </ul>
         </div>
       </div>

--- a/content/staff-wellbeing/academy-trust-workload-agreement.md
+++ b/content/staff-wellbeing/academy-trust-workload-agreement.md
@@ -1,6 +1,5 @@
 ---
 title: Academy trust workload agreement 
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/academy-trust-workload-agreement.md
+++ b/content/staff-wellbeing/academy-trust-workload-agreement.md
@@ -64,30 +64,32 @@ We developed our academy trust workload agreement to support better recruitment 
 
 How the Ascent Trust ensures fair and reasonable workload:  
 
-* the executive leadership team’s commitment to reducing work hours (above and beyond 1265) for all teachers and a Trust review of TA contractual hours and duties  
+* the executive leadership team has a commitment to reducing work hours (above and beyond 1265) for all teachers. We also carry out a Trust review of Teaching Assistant contractual hours and duties  
 
-* the appraisal of all staff should include a review of workload with a supporting action in order to ensure employers exercise their duty of care to employees with regard to workload, including heads of academy 
+* we ensure that the appraisal of all staff includes a workload review.
 
-* a total review of the Educational Health Care Plan (EHCP) reports and meetings, with Ascent (rather than individual LA) providing the lead on systems and procedures 
+* we take supporting actions to ensure employers exercise their duty of care to employees regarding workload, including heads of academy
 
-* a working party to review curriculum planning systems across the trust with the intention of reducing workload 
+* we review the Educational Health Care Plan (EHCP) reports and meetings, with Ascent (rather than local authorities) providing the lead on systems and procedures 
 
-* ensuring that before any new trust policies, reports or initiatives are introduced, Ascent completes a workload impact assessment to ensure there is no negative effect on workload 
+* we have a working party to review curriculum planning systems across the trust, with the intention of reducing workload 
 
-* ensuring that for non-teaching staff, the requirements of policies are reasonably deliverable within contracted hours 
+* we ensure that Ascent completes a workload impact assessment before any new trust policies, reports or initiatives are introduced
 
-* regularly reviewing the workload charter with all staff 
+* we ensure that policy requirements are reasonably deliverable within contracted hours for non-teaching staff
 
-Individual academies within the trust ensure fair and reasonable workload through: 
+* we regularly review the workload charter with all staff 
 
-* Senior Leadership Team (SLT) stating and planning the allocation of directed time with staff  
+How individual academies within the trust ensure fair and reasonable workload: 
 
-* the publishing and adhering to termly calendars where possible 
+* the Senior Leadership Team (SLT) states and plans the allocation of directed time with staff  
 
-* a guarantee from SLT to staff that any major changes initiated by the Trust will be planned on an annual basis and shared with staff via the Academy Improvement Plan (AIP)  
+* by publishing and adhering to termly calendars where possible 
 
-* clear expectations policies for marking, feedback and assessment 
+* the SLT guarantees to staff that any major changes initiated by the Trust will be planned on an annual basis
 
-* SLT and business support review of admin support needed in order to reduce admin duties currently undertaken by teachers 
+* by setting clear expectations policies for marking, feedback and assessment 
+
+* the SLT and business review the support needed by teachers to reduce their admin duties
 
  

--- a/content/staff-wellbeing/academy-trust-workload-agreement.md
+++ b/content/staff-wellbeing/academy-trust-workload-agreement.md
@@ -1,0 +1,94 @@
+---
+title: Academy trust workload agreement 
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Academy trust workload agreement 
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Ascent Academies' Trust
+
+**Location**: Sunderland
+
+**Phase**: Multi-academy trust focusing on special educational needs
+
+**Number of pupils**: 130 to 200
+
+**Contact details**: Email CEO Carolyn Morgan at <cmorgan@ascenttrust.org>  
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        The agreement sets out what teachers and support staff can expect from the academy and the trust they work in, in relation to their workload. It also sets out what leadership should do to manage workload.  
+      </p>
+      <p>
+        Staff at Ascent can expect:
+        <ul>
+          <li>
+            a fair and reasonable workload
+          </li>
+          <li>
+            high quality training and professional development opportunities that meet the needs of individual members of staff
+          </li>
+        </ul>
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Carolyn Morgan, CEO
+
+{inset-text}
+
+It is clear from national surveys and Ascent Trust’s own fact finding, that excessive workload is a major obstacle to schools across the country being able to successfully recruit and retain the best teachers and support staff.  
+
+We developed our academy trust workload agreement to support better recruitment and retention of teachers and support staff. 
+
+{/inset-text}
+
+## Ensuring fair and reasonable workload 
+
+Ascent Trust ensures fair and reasonable workload through:  
+
+* the executive leadership team’s commitment to reducing work hours (above and beyond 1265) for all teachers and a Trust review of TA contractual hours and duties  
+
+* the appraisal of all staff should include a review of workload with a supporting action in order to ensure employers exercise their duty of care to employees with regard to workload, including heads of academy 
+
+* a total review of the Educational Health Care Plan (EHCP) reports and meetings, with Ascent (rather than individual LA) providing the lead on systems and procedures 
+
+* a working party to review curriculum planning systems across the trust with the intention of reducing workload 
+
+* ensuring that before any new trust policies, reports or initiatives are introduced, Ascent completes a workload impact assessment to ensure there is no negative effect on workload 
+
+* ensuring that for non-teaching staff, the requirements of policies are reasonably deliverable within contracted hours 
+
+* regularly reviewing the workload charter with all staff 
+
+Individual academies within the trust ensure fair and reasonable workload through: 
+
+* Senior Leadership Team (SLT) stating and planning the allocation of directed time with staff  
+
+* the publishing and adhering to termly calendars where possible 
+
+* a guarantee from SLT to staff that any major changes initiated by the Trust will be planned on an annual basis and shared with staff via the Academy Improvement Plan (AIP)  
+
+* clear expectations policies for marking, feedback and assessment 
+
+* SLT and business support review of admin support needed in order to reduce admin duties currently undertaken by teachers 
+
+ 

--- a/content/staff-wellbeing/academy-trust-workload-agreement.md
+++ b/content/staff-wellbeing/academy-trust-workload-agreement.md
@@ -62,7 +62,7 @@ We developed our academy trust workload agreement to support better recruitment 
 
 ## Ensuring fair and reasonable workload 
 
-Ascent Trust ensures fair and reasonable workload through:  
+How the Ascent Trust ensures fair and reasonable workload:  
 
 * the executive leadership team’s commitment to reducing work hours (above and beyond 1265) for all teachers and a Trust review of TA contractual hours and duties  
 

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -1,0 +1,125 @@
+---
+title: Communicate about wellbeing to improve staff retention 
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Communicate about wellbeing to improve staff retention 
+
+<strong class="govuk-tag">Case study</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Bedford Academy   
+
+**Location**: Bedford
+
+**Phase**: Secondary
+
+**Number of pupils**: 1300
+
+**Contact details**: Email the school office at <info@heartacademiestrust.co.uk>
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        A focus on positive wellbeing had led to:
+        <ul>
+          <li>
+            more effective communication among staff  
+          </li>
+          <li>
+            improved educational outcomes for students 
+          </li>
+          <li>
+            improved career satisfaction which can support retention 
+          </li>
+          <li>
+            lower levels of staff absence
+          </li>
+          <li>
+            increased staff motivation and productivity 
+          </li>
+          <li>
+            staff turnover has reduced from 14% to 6% in the last three years 
+          </li>
+          <li>
+            raised levels of staff morale 
+          </li>
+          <li>
+            staff more able to manage stress  
+          </li>
+          <li>
+            stronger working relationships
+          </li>
+          <li>
+            a team of loyal and committed staff 
+            </li>
+      </p>
+      <p>
+        Staff have reported that wellbeing and workload has been assessed when leaders introduce new initiatives.
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from  Chris Deller, headteacher and Laura Fordham, SLT and Wellbeing Lead 
+
+{inset-text}
+
+Wellbeing is at the centre of everything we do. Three years ago we had a high staff turnover, a poor school culture of low expectations and low aspirations and a falling roll. Three years on, we have a very low staff turnover, an increased roll in year 7 and waiting lists in every year group.  
+
+ We have transformed our wider community’s perception of our school. The main platform for this change has been a considerable shift in our focus to ensuring student and staff wellbeing is at our core, with open communication to all stakeholders, regular staff consultations and a drive to improve educational standards for students in our school.   
+
+ The Trust supports individual schools to develop wellbeing strategies so that they are focused on the needs of each school as opposed to a generic approach across the Trust. 
+
+{/inset-text}
+
+## Three ways to communicate to improve staff retention 
+
+### Regular staff consultations 
+
+Staff consultations relating to staff wellness happen regularly and all staff are invited to contribute ideas. Staff are involved in whole school decisions and have an opportunity to contribute their opinions via staff voice tools. 
+
+### Form a wellbeing committee 
+
+The wellbeing committee comprises staff members and representatives from all departments that hold a range of positions within the Academy. The central aim of the committee is to promote and ensure the wellbeing of all employees at the Academy. The committee will advise the Leadership Team on all matters relating to wellbeing and report to Governors. 
+
+The full committee will meet at least once per half term.  A meeting schedule of these meetings and the membership of the committee will be regularly published to all staff.  
+
+The wellbeing committee will: 
+
+* evaluate the impact of any intervention to resolve wellbeing issues 
+
+* coordinate termly wellbeing weeks 
+
+* inform staff of wellbeing initiatives via the wellbeing notice board the monthly BA Wellbeing Newsletter and staff meetings (when appropriate) 
+
+### Set up a working group 
+
+The workload group will be formed with a different group of staff each term that will meet about staff workload and will make recommendations for colleagues and senior leadership to support staff to manage this.  
+
+The group will be representative of staff, and include a range of experience, for example:  
+
+* Early Career Teachers (ECTs)  
+
+* staff who have taught in at least one other school 
+
+* middle leaders – both pastoral and academic 
+
+* staff who have previously worked outside of teaching 
+
+* support staff 
+
+The workload group will identify priorities to support staff in managing workload and this will be disseminated to staff.  

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -78,11 +78,11 @@ colour: blue
 
 {inset-text}
 
-Wellbeing is at the centre of everything we do. Three years ago we had a high staff turnover, a poor school culture of low expectations and low aspirations and a falling roll. Three years on, we have a very low staff turnover, an increased roll in year 7 and waiting lists in every year group.  
+Wellbeing is at the centre of everything we do. Three years ago we had a high staff turnover, a poor school culture of low expectations, low aspirations and a falling roll. Three years on, we have a very low staff turnover, an increased roll in year 7 and waiting lists in every year group.  
 
- We have transformed our wider community’s perception of our school. The main platform for this change has been a considerable shift in our focus to ensuring student and staff wellbeing is at our core, with open communication to all stakeholders, regular staff consultations and a drive to improve educational standards for students in our school.   
+ We have transformed our wider community’s perception of our school. The main platform for this change has been a considerable shift in our focus, ensuring student and staff wellbeing is at our core. This has included open communication with all stakeholders, regular staff consultations and a drive to improve educational standards for students in our school.   
 
- The Trust supports individual schools to develop wellbeing strategies so that they are focused on the needs of each school as opposed to a generic approach across the Trust. 
+ The Trust supports individual schools to develop wellbeing strategies that are focused on their own needs, as opposed to a generic approach across the Trust. 
 
 {/inset-text}
 
@@ -96,7 +96,7 @@ Staff consultations relating to staff wellness happen regularly and all staff ar
 
 The wellbeing committee comprises staff members and representatives from all departments that hold a range of positions within the Academy. The central aim of the committee is to promote and ensure the wellbeing of all employees at the Academy. The committee will advise the Leadership Team on all matters relating to wellbeing and report to Governors. 
 
-The full committee will meet at least once per half term.  A meeting schedule of these meetings and the membership of the committee will be regularly published to all staff.  
+The full committee will meet at least once per half term.  A schedule of these meetings and the membership of the committee will be regularly published to all staff.  
 
 The wellbeing committee will: 
 
@@ -108,7 +108,7 @@ The wellbeing committee will:
 
 ### Set up a working group 
 
-The workload group will be formed with a different group of staff each term that will meet about staff workload and will make recommendations for colleagues and senior leadership to support staff to manage this.  
+The workload group will be formed with a different group of staff each term. They will meet to talk about staff workload and make recommendations for colleagues and senior leadership, to support staff in managing this.  
 
 The group will be representative of staff, and include a range of experience, for example:  
 

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -75,7 +75,7 @@ colour: blue
   </div>
 </div>
 
-## Background from  Chris Deller, headteacher and Laura Fordham, SLT and Wellbeing Lead 
+## Background from Chris Deller, Headteacher and Laura Fordham, SLT and Wellbeing Lead 
 
 {inset-text}
 

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -74,7 +74,7 @@ colour: blue
   </div>
 </div>
 
-## Background from Chris Deller, Headteacher and Laura Fordham, SLT and Wellbeing Lead 
+## Background from Chris Deller, Headteacher and Laura Fordham, senior leader and wellbeing lead 
 
 {inset-text}
 

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -65,7 +65,8 @@ colour: blue
           </li>
           <li>
             a team of loyal and committed staff 
-            </li>
+          </li>
+        </ul>
       </p>
       <p>
         Staff have reported that wellbeing and workload has been assessed when leaders introduce new initiatives.

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -1,6 +1,5 @@
 ---
 title: Communicate about wellbeing to improve staff retention 
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
+++ b/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
@@ -1,6 +1,5 @@
 ---
 title: Create a school culture which improves wellbeing
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
+++ b/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
@@ -97,7 +97,7 @@ Throughout, we have worked with staff. This has taken many forms – both formal
 
 There are many times when we have adapted what we were doing because the pace of change meant that cracks were beginning to show.  
 
-We now have “Kensington Matters” groups – cross-sections of staff that get feedback on key initiatives and how these are rolling out across the school.  
+We now have 'Kensington Matters' groups – cross-sections of staff that get feedback on key initiatives and how these are rolling out across the school.  
 
 We regularly play a game called ‘keep, tweak or ditch’, where we ask staff and children to organise different initiatives into the three categories. We then use this to evaluate work and decide on next steps.  
 
@@ -117,4 +117,4 @@ We also spent time considering Pareto’s Law: 20% of the inputs create 80% of t
 
 All of this is part of an ongoing process. As the school continues to change, we will tweak some initiatives and ditch others.  
 
-What won’t change is our focus on staff wellbeing. Teaching is an incredibly demanding profession, we strongly believe that for the children to be the best they can be, we need to take care of ourselves and each other. 
+What won’t change is our focus on staff wellbeing. Teaching is an incredibly demanding profession. We strongly believe that for the children to be the best they can be, we need to take care of ourselves and each other. 

--- a/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
+++ b/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
@@ -1,0 +1,121 @@
+---
+title: Create a school culture which improves wellbeing
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Create a school culture which improves wellbeing
+
+<strong class="govuk-tag">Case study</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Kensington Primary School     
+
+**Location**: Newham
+
+**Phase**: Primary
+
+**Number of pupils**: 700
+
+**Contact details**: Email headteacher Ben Levinson at <info@kensington.ttlt.academy> 
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        By engaging with our staff about workload, we have created a culture of wellbeing and ongoing reflection.  
+      </p>
+      <p>
+        We have relentlessly removed unnecessary tasks or reduced them to their essential components, especially when the justification for doing them was ‘that’s what everyone else does’ or ‘that’s what OFSTED, DfE or some other body want’.  
+      </p>
+      <p>
+        As a result, in our most recent wellbeing survey, 95% of our staff believed they completed their work ‘on time’ and, consequently, over 70% answered ‘very much so’ to the question: do you have a life outside work?  
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Ben Levinson, Headteacher
+
+{inset-text}
+
+We have always focused on thinking about what we do and why. This is one of our guiding principles at Kensington Primary School.  
+
+At the heart of it all is the school’s culture and ethos. Without getting this right, I strongly believe that any initiatives or ideas will fall flat. Below I’ve tried to distil some of the key components of the work that we have done. You can also [watch a short video about our work](https://www.youtube.com/watch?v=7A69oyTaCX4).  
+
+{/inset-text}
+
+## Wellbeing and workload are central to our culture 
+
+Call it what you want – vision, ethos, culture – for us, what we believe and what we stand for is at the centre of everything we do. We worked hard to ensure this was clear and concise rather than bland, meaningless, one-size fits all management-speak.  
+
+Our vision: a place everyone loves to be. 
+
+Our strategic goals: all in this together; take care of ourselves and each other. 
+
+Our guiding principle: thinking about what we do and why. 
+
+For us, if our ethos didn’t link in some way to workload, then we believed initiatives were doomed to fail. You can put in place any policies you want but if your senior and middle leaders are demanding more, more, more, then they won’t be worth the paper they’re written on. 
+
+## Empower staff by improving workload 
+
+In the early days, we felt that staff weren’t sufficiently engaged in our approach to make the best decisions for the children. Therefore, our early initiatives focused on hard, practical realities:  
+
+* changing the timetable 
+
+* providing medium term plans as a starting point 
+
+* blocking out time for staff to undertake continuing professional development (CPD) 
+
+* removing telephones from classrooms 
+
+* creating a school calendar 
+
+Over time, we have empowered staff to use their professional judgement to make the best decisions for their children. This can be seen in our [marking policy](https://improve-workload-and-wellbeing-for-school-staff.education.gov.uk/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils/), which encourages you to mark when you believe it will make the greatest impact on teaching.  
+
+## Work together and support when needed 
+
+We strongly believe that we are all in this together. We do not monitor staff or tell them off if they haven’t marked their books. Everyone here is doing the best job they can do.  
+
+Inevitably, there are times – for all of us – where our focus is distracted, or we need some support. When this happens, we work as a team.  
+
+If it looks like a teacher is doing too much, we will work with them to help identify how they can effectively use their time. Equally, if opportunities for feedback are being missed, we will help them identify when best to intervene. 
+
+## Engage with all staff regularly 
+
+Throughout, we have worked with staff. This has taken many forms – both formal and informal.  
+
+There are many times when we have adapted what we were doing because the pace of change meant that cracks were beginning to show.  
+
+We now have “Kensington Matters” groups – cross-sections of staff that get feedback on key initiatives and how these are rolling out across the school.  
+
+We regularly play a game called ‘keep, tweak or ditch’, where we ask staff and children to organise different initiatives into the three categories. We then use this to evaluate work and decide on next steps.  
+
+Every year we ask staff to [list anything they do that doesn’t positively impact pupils](https://improve-workload-and-wellbeing-for-school-staff.education.gov.uk/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs). This has dwindled from a full sheet of post-it notes in the first year to one or two at the last attempt. 
+
+## Use research to inform these decisions 
+
+There is a huge amount of research on education. There is also your lived experience. 
+
+The reality is there isn’t enough time in the day. We wanted everyone to be making explicit decisions about which tasks were prioritised and which were left, based on research. 
+
+When we considered what we do and why, we used the research from the Education Endowment Foundation and John Hattie on what works as starting points.  
+
+We also spent time considering Pareto’s Law: 20% of the inputs create 80% of the outputs. We discussed what we believed the 20% was for us and then supported staff to focus on doing these first and foremost.  
+
+## Be open to changing your approach 
+
+All of this is part of an ongoing process. As the school continues to change, we will tweak some initiatives and ditch others.  
+
+What won’t change is our focus on staff wellbeing. Teaching is an incredibly demanding profession, we strongly believe that for the children to be the best they can be, we need to take care of ourselves and each other. 

--- a/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
+++ b/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
@@ -81,7 +81,7 @@ In the early days, we felt that staff weren’t sufficiently engaged in our appr
 
 * creating a school calendar 
 
-Over time, we have empowered staff to use their professional judgement to make the best decisions for their children. This can be seen in our [marking policy](https://improve-workload-and-wellbeing-for-school-staff.education.gov.uk/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils/), which encourages you to mark when you believe it will make the greatest impact on teaching.  
+Over time, we have empowered staff to use their professional judgement to make the best decisions for their children. This can be seen in our [marking policy](/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils/), which encourages you to mark when you believe it will make the greatest impact on teaching.  
 
 ## Work together and support when needed 
 

--- a/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
+++ b/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
@@ -101,7 +101,7 @@ We now have “Kensington Matters” groups – cross-sections of staff that get
 
 We regularly play a game called ‘keep, tweak or ditch’, where we ask staff and children to organise different initiatives into the three categories. We then use this to evaluate work and decide on next steps.  
 
-Every year we ask staff to [list anything they do that doesn’t positively impact pupils](https://improve-workload-and-wellbeing-for-school-staff.education.gov.uk/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs). This has dwindled from a full sheet of post-it notes in the first year to one or two at the last attempt. 
+Every year we ask staff to [list anything they do that doesn’t positively impact pupils](/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs). This has dwindled from a full sheet of post-it notes in the first year to one or two at the last attempt. 
 
 ## Use research to inform these decisions 
 

--- a/content/staff-wellbeing/establish-a-school-workload-group.md
+++ b/content/staff-wellbeing/establish-a-school-workload-group.md
@@ -60,7 +60,7 @@ Baylis Court School set up a working group to address staff workload. This was f
 
 School leaders recognised that they needed to better understand the workload of teaching staff. Leaders wanted to develop possible strategies that would reduce workload for teachers without increasing it for others.  
 
-The group was chaired by a member of the senior leadership team to ensure that there was direct feedback from the group to senior leaders of the school. 
+The group was chaired by a senior leadership team (SLT) member to ensure that direct feedback was given to senior leaders of the school. 
 
 ## How we established our workload group 
 
@@ -72,9 +72,9 @@ For example, to receive feedback on a termly basis about staff workload, and rec
 
 Membership should be representative of staff, and include a range of experience, for example: 
 
-* NQTs 
+* newly qualified teachers (NQTs) 
 
-* teachers 2/3 years into teaching 
+* teachers 2 or 3 years into teaching 
 
 * staff who have taught in at least one other school 
 
@@ -102,7 +102,7 @@ Identify priorities to support staff in managing workload, for example:
 
 * the imbalance between all-staff meetings, department time and individual time 
 
-* scheduling of assessment weeks adjacent to other tasks that may cause more workload, for example, book scrutiny, creating excessive workload at key points each half term 
+* scheduling of assessment weeks adjacent to other tasks that may cause more workload, such as book scrutinies every half term
 
 * excessive volume of data entry required due to assessment changes 
 
@@ -112,11 +112,11 @@ Identify priorities to support staff in managing workload, for example:
 
 Develop an action plan and disseminate this to staff. Examples of actions: 
 
-* review the school’s draft teaching and learning calendar, and make recommendations to support reduction of ‘pressure points’ 
+* review the school’s draft teaching and learning calendar, to make recommendations to support reduction of ‘pressure points’ 
 
 * produce a weekly staff bulletin, to better support communication with staff and reduce the number of meetings and separate emails   
 
-* implement relevant recommendations from the DfE, for example, reduction of the number of data collection points per academic year, ensuring that these were purposeful and minimising marking burdens 
+* implement relevant recommendations from the DfE, such as reducing the number of data collection points per academic year
 
 * effective training for staff on use of IT systems 
 

--- a/content/staff-wellbeing/establish-a-school-workload-group.md
+++ b/content/staff-wellbeing/establish-a-school-workload-group.md
@@ -1,0 +1,129 @@
+---
+title: Establish a school workload group
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Establish a school workload group
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Baylis Court School   
+
+**Location**: Slough
+
+**Phase**: Secondary
+
+**Number of pupils**: 900
+
+**Contact details**: Email CEO Richard Kearsey at <RKearsey@bayliscourttrust.co.uk>  
+
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        Two examples of outcomes achieved by the school workload group at Baylis Court School were:
+        <ul>
+          <li>
+            the amount of data being gathered was reduced, and therefore the time being spent by staff inputting it without any detrimental impact on pupil outcomes
+          </li> 
+          <li>
+          staff have become more confident in the use of IT and feel they can work more efficiently
+          </li>
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Richard Kearsey, CEO
+
+{inset-text}
+
+Baylis Court School set up a working group to address staff workload. This was following the involvement of the executive headteacher in the independent teacher workload review groups for data management.  
+
+{/inset-text}
+
+## Why we set up a workload group 
+
+School leaders recognised that they needed to better understand the workload of teaching staff. Leaders wanted to develop possible strategies that would reduce workload for teachers without increasing it for others.  
+
+The group was chaired by a member of the senior leadership team to ensure that there was direct feedback from the group to senior leaders of the school. 
+
+## How we established our workload group 
+
+### Decide on the purpose of the group 
+
+For example, to receive feedback on a termly basis about staff workload, and recommendations for colleagues and senior leadership to support staff to manage this.  
+
+### Decide members of the group 
+
+Membership should be representative of staff, and include a range of experience, for example: 
+
+* NQTs 
+
+* teachers 2/3 years into teaching 
+
+* staff who have taught in at least one other school 
+
+* middle leaders – both pastoral and academic 
+
+* staff who have previously worked outside of teaching 
+
+* support staff 
+
+* union representatives 
+
+### Identify priorities of the group 
+
+Identify priorities to support staff in managing workload, for example: 
+
+* time taken up by replying to e-mail and face-to-face requests for information 
+
+* further training on ‘remote access’ for staff 
+
+* perceived excessive marking burden 
+
+* relevance of some weekly CPD sessions for all staff 
+
+* lack of clarity about how staff are meant to spend their directed time 
+
+* the imbalance between all-staff meetings, department time and individual time 
+
+* scheduling of assessment weeks adjacent to other tasks that may cause more workload, for example, book scrutiny, creating excessive workload at key points each half term 
+
+* excessive volume of data entry required due to assessment changes 
+
+* teachers having to provide work for students removed from lessons 
+
+## Develop an action plan 
+
+Develop an action plan and disseminate this to staff. Examples of actions: 
+
+* review the school’s draft teaching and learning calendar, and make recommendations to support reduction of ‘pressure points’ 
+
+* produce a weekly staff bulletin, to better support communication with staff and reduce the number of meetings and separate emails   
+
+* implement relevant recommendations from the DfE, for example, reduction of the number of data collection points per academic year, ensuring that these were purposeful and minimising marking burdens 
+
+* effective training for staff on use of IT systems 
+
+Staff working on these actions, for example, producing the bulletin, should be freed up from other tasks where appropriate. 
+
+## Evaluate the impact of the group 
+
+Evaluate the ongoing impact of the group and share findings with staff.  
+
+You could group representatives to run an INSET session to feed back on the work and impact of the group and seek further recommendations. 

--- a/content/staff-wellbeing/establish-a-school-workload-group.md
+++ b/content/staff-wellbeing/establish-a-school-workload-group.md
@@ -1,6 +1,5 @@
 ---
 title: Establish a school workload group
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/establish-a-school-workload-group.md
+++ b/content/staff-wellbeing/establish-a-school-workload-group.md
@@ -40,8 +40,9 @@ colour: blue
             the amount of data being gathered was reduced, and therefore the time being spent by staff inputting it without any detrimental impact on pupil outcomes
           </li> 
           <li>
-          staff have become more confident in the use of IT and feel they can work more efficiently
+            staff have become more confident in the use of IT and feel they can work more efficiently
           </li>
+        </ul>
       </p>
     </div>
   </div>

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -1,6 +1,5 @@
 ---
 title: Make a list of everything you do to improve wellbeing 
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -40,6 +40,7 @@ colour: blue
         <li>
           think about what else you could do 
         </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -1,0 +1,154 @@
+---
+title: Make a list of everything you do to improve wellbeing 
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Barr Beacon School
+
+<strong class="govuk-tag">Case study</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Barr Beacon School     
+
+**Location**: Walsall, West Midlands 
+
+**Phase**: Secondary 
+
+**Number of pupils**: 1500
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        Making a list of everything you do to reduce workload and improve wellbeing can help you:
+      </p>
+      <ul>
+        <li>
+          remind yourself of everything you’ve done already 
+        </li>
+        <li>
+          think about what else you could do 
+        </li>
+    </div>
+  </div>
+</div>
+
+## Background from Deputy Headteacher David Lowbridge-Ellis
+
+{inset-text}
+
+Our list helps us to see what we might do next. We’re always looking at policies and practices to see what our next step could be.  
+
+Teacher workload will not be sorted overnight, but making a list of what you already do is a good way to start. 
+
+{/inset-text}
+
+## Our list of what we do to reduce workload and improve wellbeing 
+
+### Trust our teachers  
+
+Our teachers decide on the best approach for their pupils. They choose how to: 
+
+* adapt schemes of work 
+
+* give feedback to pupils 
+
+* plan lessons (we do not ask them to write lesson plans) 
+
+They also design our teaching and learning policies with us because they know what works best for different subjects.  
+
+We do not grade teachers’ lessons, or expect them to look busy or stay late. 
+
+### Support professional development  
+
+We do not have a hierarchical approach to professional development, recognising that a senior leader can learn from an early career teacher and vice versa. We: 
+
+* support teachers to complete NPQs 
+
+* fund teachers who want to achieve Chartered Status 
+
+* tailor professional development to staff needs 
+
+* ensure that any professional development finishes no later than 4:15pm and time off in lieu is given  
+
+* ensure that early career teachers have comprehensive support – for example, they have regular meetups, dedicated mentors, coaching and study visits abroad  
+
+* support teachers at all levels to learn from each other – for example, middle leaders shadow senior leaders  
+
+* have a bespoke development package for second and third year teachers 
+
+###Socialise and support one another 
+
+We: 
+
+* organise regular staff events outside school 
+
+* have a culture of peer to peer praise – for example, teachers send thank you cards or letters 
+
+### Look after staff health 
+
+We offer free flu jabs and health checks in school.  
+
+### Protect staff time  
+
+We: 
+
+* do not have meetings just because they’re in the calendar – we use meetings to talk about curriculum and how we’ll organise, plan and schedule our curriculum 
+
+* take something away if something new is introduced  
+
+* avoid unnecessary data entry - data is never entered twice and we do not record data that we will not use 
+
+* streamline all our systems and processes where possible 
+
+* have a central media team who make lesson resources, such as videos  
+
+* mark only for the benefits of pupils - not for observers, parents and carers 
+
+We do not expect teachers to: 
+
+* respond to emails outside of school hours 
+
+* email or phone parents and carers – our administrative team does this 
+
+* write written reports for parents and carers 
+
+* spend more than an hour when giving feedback on any class or set of books or essays 
+
+* cover more than one lesson every half term 
+
+* teach more than 22 out of 25 periods per week 
+
+### Seek staff feedback  
+
+We ask staff to provide feedback regularly through surveys.  
+
+Staff can talk to the senior leadership team about any concern, no matter how small. 
+
+### Reduce behavior management workload 
+
+The senior leadership team help to prevent behavioural issues coming up in class by running lunch duty.  
+
+We have a rota system to ensure that pupils always see a familiar face and no cover is required. A familiar face better represents the school’s expectations for behaviour. 
+
+All staff reinforce our high expectations of behaviour, and we use sections consistently so that pupils accept them.  
+
+### Support teachers to progress up the pay scale  
+
+We support teachers to progress up the pay scale if they’ve done all they can to improve pupil outcomes.  
+
+We also support teachers to move further up the pay scale between their third and fourth year of teaching where appropriate. 
+
+We tailor performance management to the individual’s development needs.  

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -45,7 +45,7 @@ colour: blue
   </div>
 </div>
 
-## Background from Deputy Headteacher David Lowbridge-Ellis
+## Background from David Lowbridge-Ellis, Deputy Headteacher
 
 {inset-text}
 

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -89,7 +89,7 @@ We do not have a hierarchical approach to professional development, recognising 
 
 * have a bespoke development package for second and third year teachers 
 
-###Socialise and support one another 
+### Socialise and support one another 
 
 We: 
 

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -73,7 +73,7 @@ We do not grade teachers’ lessons, or expect them to look busy or stay late.
 
 ### Support professional development  
 
-We do not have a hierarchical approach to professional development, recognising that a senior leader can learn from an early career teacher and vice versa. We: 
+We do not have a hierarchical approach to professional development, recognising that a senior leader can learn from an early career teacher (ECT) and vice versa. We: 
 
 * support teachers to complete NPQs 
 
@@ -83,9 +83,9 @@ We do not have a hierarchical approach to professional development, recognising 
 
 * ensure that any professional development finishes no later than 4:15pm and time off in lieu is given  
 
-* ensure that early career teachers have comprehensive support – for example, they have regular meetups, dedicated mentors, coaching and study visits abroad  
+* ensure that ECTs have comprehensive support such as regular meetups, dedicated mentors, coaching and study visits abroad  
 
-* support teachers at all levels to learn from each other – for example, middle leaders shadow senior leaders  
+* support teachers at all levels to learn from each other, such as middle leaders shadowing senior leaders  
 
 * have a bespoke development package for second and third year teachers 
 
@@ -95,7 +95,7 @@ We:
 
 * organise regular staff events outside school 
 
-* have a culture of peer to peer praise – for example, teachers send thank you cards or letters 
+* have a culture of peer-to-peer praise
 
 ### Look after staff health 
 
@@ -105,11 +105,15 @@ We offer free flu jabs and health checks in school.
 
 We: 
 
-* do not have meetings just because they’re in the calendar – we use meetings to talk about curriculum and how we’ll organise, plan and schedule our curriculum 
+* do not have meetings just because they’re in the calendar
+
+* we use meetings to talk about the curriculum and how we’ll organise, plan and schedule it 
 
 * take something away if something new is introduced  
 
-* avoid unnecessary data entry - data is never entered twice and we do not record data that we will not use 
+* avoid unnecessary data entry
+
+* make sure data is never entered twice and we do not record data that we will not use 
 
 * streamline all our systems and processes where possible 
 
@@ -135,11 +139,11 @@ We do not expect teachers to:
 
 We ask staff to provide feedback regularly through surveys.  
 
-Staff can talk to the senior leadership team about any concern, no matter how small. 
+Staff can talk to the senior leadership team (SLT) about any concern, no matter how small. 
 
 ### Reduce behavior management workload 
 
-The senior leadership team help to prevent behavioural issues coming up in class by running lunch duty.  
+The SLT help to prevent behavioural issues coming up in class by running lunch duty.  
 
 We have a rota system to ensure that pupils always see a familiar face and no cover is required. A familiar face better represents the school’s expectations for behaviour. 
 

--- a/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
+++ b/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
@@ -42,7 +42,7 @@ colour: blue
   </div>
 </div>
 
-## Background from Headteacher Julie Kelly
+## Background from Julie Kelly, Headteacher
 
 {inset-text}
 

--- a/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
+++ b/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
@@ -1,0 +1,110 @@
+---
+title: Protect staff time and improve wellbeing
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Protect staff time and improve wellbeing
+
+<strong class="govuk-tag">Case study</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: West Meon CofE Primary School
+
+**Location**: Hampshire
+
+**Phase**: Primary
+
+**Number of pupils**: Less than 100
+
+**Contact details**: Email the school at <admin@westmeon.hants.sch.uk> 
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        As a small school with just 3 members of full-time staff, we had to protect staff time carefully.
+      </p>
+      <p>  
+        We ensured that we had the time to give to the large number of subjects we are responsible for, given the small number of us. 
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Headteacher Julie Kelly
+
+{inset-text}
+
+Being a small school meant that we had to strategically plan how to manage all the various roles every school has to undertake.  
+
+We had to ensure that all roles and responsibilities are covered whilst creating and maintaining a sustainable workload for each member of staff. 
+
+{/inset-text}
+
+## Use your communications channels to reduce questions from parents  
+
+You can give parents the information they need through your website and newsletter, reducing the number of individual questions from parents to staff.  
+
+Our administrative officer produces our newsletters and manages our website. 
+
+## If you add something, take something else away 
+
+If extra meetings occur after school, staff meetings are not held. 
+
+For example, we do not have a staff meeting on the week of a parents’ information meeting. 
+
+We also have joint staff meetings with other schools. When we do this, we swap our local school staff meeting with the joint staff meeting.  
+
+## Save time on routine tasks 
+
+We invested in a school business manager to relieve the headteacher of routine tasks, such as tasks relating to finance and premises.  
+
+We also invested in CPOMS, an electronic recording system for safeguarding concerns, which saves on days spent on preparing casework.  
+
+## Invest in teaching assistants 
+
+Teaching assistants can help improve staff wellbeing and help pupils to progress.   
+
+We invest in training for teaching assistants and prioritise budget for them.  
+
+We also invest in ex-teachers who wanted to step back and are now supporting teaching assistants to train in school to be teachers.
+
+## Provide time off timetable for longer projects 
+
+We give teachers additional time off timetable time to complete longer projects and tasks.  
+
+The senior leadership team or supply teachers cover their time off timetable.  
+
+## Manage the demands of the year 
+
+We manage the demands of the year by: 
+
+* planning our school calendar together 
+
+* being clear about what will happen and when it will happen, as part of directed time 
+
+* sharing the directed time calendar with staff before the start of new school year 
+
+## Offer temporary responsibilities  
+
+TLR3s (a type of teaching and learning responsibility) allow teachers to take on time limited responsibilities.  
+
+If staff do not want to take on extra responsibilities permanently, a TLR3 can fit in with their work-life balance.  
+
+## Promote flexible working 
+
+Promoting flexible working is invaluable in a small school. 
+
+Although there may be a financial impact, there is always someone who can step up to ensure continuity and support the team when needed. 

--- a/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
+++ b/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
@@ -1,6 +1,5 @@
 ---
 title: Protect staff time and improve wellbeing
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
+++ b/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
@@ -82,7 +82,7 @@ We also invest in ex-teachers who wanted to step back and are now supporting tea
 
 ## Provide time off timetable for longer projects 
 
-We give teachers additional time off timetable time to complete longer projects and tasks.  
+We give teachers additional time off from their timetable to complete longer projects and tasks.  
 
 The senior leadership team or supply teachers cover their time off timetable.  
 

--- a/content/staff-wellbeing/staff-wellbeing-policy.md
+++ b/content/staff-wellbeing/staff-wellbeing-policy.md
@@ -77,7 +77,10 @@ colour: blue
 
 At the Pingle Academy we have introduced practices to support staff wellbeing.  
 
-For example, we train line managers at all levels, we have reduced the volume of emails sent to staff, and we avoid directed time after 4:30pm.  
+For example, we: 
+* train line managers at all levels
+* reduced the volume of emails sent to staff
+* avoid directed time after 4:30pm.  
 
 Staff have access to a number of resources to support their mental health. 
 
@@ -125,23 +128,25 @@ All staff are expected to:
 
 Line managers are expected to: 
 
-* monitor workloads, be alert to signs of stress and regularly talk to staff about their work life balance 
+* monitor workloads, be alert to signs of stress and regularly talk to staff about their work-life balance 
 
 * maintain positive relationships with their staff and value them for their skills and contributions, not their working pattern 
 
 * familiarise themselves with trust and academy policies related to wellbeing 
 
-* feature discussion of wellbeing as part of line management and faculty meetings 
+* discuss wellbeing as part of line management and faculty meetings 
 
 * make sure new staff are given a thorough induction programme and feel able to ask for help  
 
 * provide a non-judgemental and confidential support system to their staff 
 
-* understand that personal issues and pressures at work may have a temporary effect on work performance and take that into account during any appraisal or capability procedures 
+* understand that personal issues and pressures at work may have a temporary effect on work performance
+
+* make sure any personal  issues are taken into account during any appraisal or capability procedures 
 
 * promote information about, and access to, external support services 
 
-* help to arrange personal and professional development training where appropriate 
+* help arrange personal and professional development training where appropriate 
 
 * keep in touch with staff if they are absent for long periods and conduct return to work interviews to support staff back into work 
 
@@ -159,13 +164,15 @@ Senior staff are expected to:
 
 * manage a non-judgemental and confidential support system for staff 
 
-* monitor the wellbeing of staff through regular surveys and structured conversations. 
+* monitor the wellbeing of staff through regular surveys and structured conversations
 
 * make sure accountability systems are based on trust and professional dialogue, with proportionate amounts of direct monitoring 
 
 * regularly review the demands on staff, such as the time spent on paperwork, and seek alternative solutions wherever possible 
 
-* make sure job descriptions are kept up to date, with clearly identified responsibilities, and consult staff before any changes 
+* make sure job descriptions are kept up-to-date, with clearly identified responsibilities
+
+* consult staff before any changes are made to job descriptions
 
 * listen to the views of staff and involve them in decision-making processes, including consideration of any workload implications of new initiatives 
 
@@ -215,7 +222,7 @@ The local governing body is expected to:
 
 ## Managing specific wellbeing issues 
 
-The academy will support and discuss options with any member of staff who raises wellbeing issues, such as if they are experiencing significant stress at the academy or in their personal lives.  
+The academy will support and discuss options with any member of staff who raises wellbeing issues. This can include situations where they are experiencing significant stress at the academy or in their personal lives.  
 
 Where possible, support will be given by line managers or senior staff.  
 
@@ -225,13 +232,15 @@ Support could be given through:
 
 * reassessing their workload and deciding what tasks to prioritise 
 
-* temporarily relieving of some duties 
+* temporarily relieving them of some duties 
 
 * giving staff time off to deal with a personal crisis 
 
 * arranging external support, such as counselling or occupational health services 
 
-* the flexible working hours policy – this policy aims to cater for the needs of all staff and wherever possible the principal supports requests from staff for reduced or part time working where personal circumstances mean that it would improve their work-life balance 
+* the flexible working hours policy, which aims to cater for the needs of all staff
+
+* the principal supporting requests from staff for reduced or part-time working, where personal circumstances mean that it would improve their work-life balance 
 
 * completing a risk assessment and following through with any actions identified 
 
@@ -239,7 +248,7 @@ Support could be given through:
 
 ## Academy wellbeing committee and plan 
 
-The academy will facilitate a wellbeing committee with members from across the staff whose role will be to develop an action plan to promote a range of wellbeing interventions. It will: 
+The academy will facilitate a wellbeing committee with members from across the staff. Their role will be to develop an action plan to promote a range of wellbeing interventions. It will: 
 
 * seek the views of staff on wellbeing regularly and promote and communicate wellbeing activities   
 

--- a/content/staff-wellbeing/staff-wellbeing-policy.md
+++ b/content/staff-wellbeing/staff-wellbeing-policy.md
@@ -71,7 +71,7 @@ colour: blue
   </div>
 </div>
 
-## Background from Vice Principal Mary Hall
+## Background from Mary Hall, Vice Principal
 
 {inset-text}
 

--- a/content/staff-wellbeing/staff-wellbeing-policy.md
+++ b/content/staff-wellbeing/staff-wellbeing-policy.md
@@ -168,7 +168,7 @@ Senior staff are expected to:
 
 * make sure accountability systems are based on trust and professional dialogue, with proportionate amounts of direct monitoring 
 
-* regularly review the demands on staff, such as the time spent on paperwork, and seek alternative solutions wherever possible 
+* regularly review the demands on staff, such as the time spent on paperwork
 
 * make sure job descriptions are kept up-to-date, with clearly identified responsibilities
 

--- a/content/staff-wellbeing/staff-wellbeing-policy.md
+++ b/content/staff-wellbeing/staff-wellbeing-policy.md
@@ -1,0 +1,247 @@
+---
+title: Staff wellbeing policy 
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Staff wellbeing policy 
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: The Pingle Academy   
+
+**Location**: Derbyshire
+
+**Phase**: Secondary
+
+**Number of pupils**: 1300
+
+**Contact details**: Email Vice Principal Mary Hall at <mhall.pingle@deferrerstrust.com>  
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        A wellbeing policy helped the Pingle Academy to: 
+      <ul>
+        <li>
+          improve recruitment and retention
+        </li>
+        <li>
+          receive positive Ofsted feedback
+        </li>
+        <li>
+          receive positive feedback from staff on a range of wellbeing themes
+        </li>
+        <li>
+          achieve high engagement from staff with additional lessons or interventions – this is rewarded with time in lieu
+        </li>
+        <li>
+          achieve openness about wellbeing – staff communicate with team leaders and this is supported by a HR follow up
+        </li> 
+        <li>
+          engage collaboratively with professional organisations on academy improvement
+        </li>
+        <li>
+          appoint a lead governor for wellbeing 
+        </li>
+        <li>
+          appoint a mental health lead who works across the trust 
+        </li>
+        <li>
+          get support from the local governing body with its wellbeing plans
+        </li>
+      </ul>
+      </p>
+      <p>
+      'Leaders are considerate of staff and pay careful attention to their workload. One member of staff summed up the views of others in saying, “We look out for each other”.’ (Ofsted report)
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Vice Principal Mary Hall
+
+{inset-text}
+
+At the Pingle Academy we have introduced practices to support staff wellbeing.  
+
+For example, we train line managers at all levels, we have reduced the volume of emails sent to staff, and we avoid directed time after 4:30pm.  
+
+Staff have access to a number of resources to support their mental health. 
+
+Our policy aligns with our trust’s wellbeing strategy. 
+
+{/inset-text}
+
+## The Pingle Academy’s staff wellbeing policy  
+
+This policy aims to: 
+
+* support the wellbeing of all staff to avoid negative impacts on their mental and physical health 
+
+* provide a supportive work environment for all staff 
+
+* acknowledge the needs of staff and how these change over time 
+
+* allow staff to balance their working lives with their personal needs and responsibilities 
+
+* help staff with any specific wellbeing issues they experience 
+
+* ensure that staff understand their role in working towards the above aims 
+
+* consider the needs of individuals 
+
+* create an environment where wellbeing is part of daily practice 
+
+## Role of all staff 
+
+All staff are expected to: 
+
+* treat each other with empathy and respect 
+
+* keep in mind the workload and wellbeing of other members of staff 
+
+* support other members of staff if they become stressed, such as by providing practical assistance or emotional reassurance 
+
+* speak honestly about their wellbeing and let other members of staff know when they need support 
+
+* contribute positively towards morale and team spirit 
+
+* use shared areas respectfully, such as the staff room  
+
+## Role of line managers 
+
+Line managers are expected to: 
+
+* monitor workloads, be alert to signs of stress and regularly talk to staff about their work life balance 
+
+* maintain positive relationships with their staff and value them for their skills and contributions, not their working pattern 
+
+* familiarise themselves with trust and academy policies related to wellbeing 
+
+* feature discussion of wellbeing as part of line management and faculty meetings 
+
+* make sure new staff are given a thorough induction programme and feel able to ask for help  
+
+* provide a non-judgemental and confidential support system to their staff 
+
+* understand that personal issues and pressures at work may have a temporary effect on work performance and take that into account during any appraisal or capability procedures 
+
+* promote information about, and access to, external support services 
+
+* help to arrange personal and professional development training where appropriate 
+
+* keep in touch with staff if they are absent for long periods and conduct return to work interviews to support staff back into work 
+
+* conduct exit interviews with resigning staff to help identify whether any wellbeing issues lead to their resignation 
+
+* take any complaints or concerns seriously and deal with them appropriately using the academy’s policies 
+
+## Role of senior staff 
+
+The principal, vice principal and business office manager are responsible for wellbeing across the academy. 
+
+Senior staff are expected to: 
+
+* lead in setting standards for conduct, including how they treat other members of staff and being respectful of agreed working hours 
+
+* manage a non-judgemental and confidential support system for staff 
+
+* monitor the wellbeing of staff through regular surveys and structured conversations. 
+
+* make sure accountability systems are based on trust and professional dialogue, with proportionate amounts of direct monitoring 
+
+* regularly review the demands on staff, such as the time spent on paperwork, and seek alternative solutions wherever possible 
+
+* make sure job descriptions are kept up to date, with clearly identified responsibilities, and consult staff before any changes 
+
+* listen to the views of staff and involve them in decision-making processes, including consideration of any workload implications of new initiatives 
+
+* communicate new initiatives effectively to all members of staff to ensure they feel included and aware of any changes occurring at the academy 
+
+* make sure that the efforts and successes of staff are recognised and celebrated 
+
+* produce calendars of meetings, deadlines and events so that staff can plan ahead and manage their workload 
+
+* provide resources to promote staff wellbeing, such as training opportunities 
+
+* promote information about and access to external support services 
+
+* organise extra support during times of stress, such as Ofsted inspections 
+
+* welcome suggestions and give feedback 
+
+## Role of the principal 
+
+Creating a positive and supportive atmosphere throughout the school, the principal will: 
+
+* operate an open-door policy for all staff 
+
+* ensure that all polices that affect staff wellbeing are adhered to and reviewed 
+
+* monitor staff attendance data 
+
+* appraise the governing board of issues to do with staff wellbeing 
+
+* consult with representatives from unions regarding staff wellbeing 
+
+## Role of the local governing body  
+
+The local governing body is expected to: 
+
+* make sure the academy is fulfilling its duty of care as an employer, such as by giving staff a reasonable workload and creating a supportive work environment 
+
+* monitor and support the wellbeing of the principal 
+
+* make decisions and review policies with staff wellbeing in mind, particularly in regard to workload 
+
+* be reasonable about the format and quantity of information asked for from staff as part of monitoring work 
+
+* ensure that resources and support services are in place to promote staff wellbeing 
+
+* ensure that staff are clear about the purpose of any monitoring visits and what information will be required from them 
+
+## Managing specific wellbeing issues 
+
+The academy will support and discuss options with any member of staff who raises wellbeing issues, such as if they are experiencing significant stress at the academy or in their personal lives.  
+
+Where possible, support will be given by line managers or senior staff.  
+
+At all times, the confidentiality and dignity of staff will be maintained.  
+
+Support could be given through: 
+
+* reassessing their workload and deciding what tasks to prioritise 
+
+* temporarily relieving of some duties 
+
+* giving staff time off to deal with a personal crisis 
+
+* arranging external support, such as counselling or occupational health services 
+
+* the flexible working hours policy – this policy aims to cater for the needs of all staff and wherever possible the principal supports requests from staff for reduced or part time working where personal circumstances mean that it would improve their work-life balance 
+
+* completing a risk assessment and following through with any actions identified 
+
+* phased return or altered hours after absence 
+
+## Academy wellbeing committee and plan 
+
+The academy will facilitate a wellbeing committee with members from across the staff whose role will be to develop an action plan to promote a range of wellbeing interventions. It will: 
+
+* seek the views of staff on wellbeing regularly and promote and communicate wellbeing activities   
+
+* represent the academy as part of the Trust Change Champion Group 

--- a/content/staff-wellbeing/staff-wellbeing-policy.md
+++ b/content/staff-wellbeing/staff-wellbeing-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Staff wellbeing policy 
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/staff-wellbeing-statement.md
+++ b/content/staff-wellbeing/staff-wellbeing-statement.md
@@ -1,6 +1,5 @@
 ---
 title: Staff wellbeing statement
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/staff-wellbeing-statement.md
+++ b/content/staff-wellbeing/staff-wellbeing-statement.md
@@ -1,0 +1,134 @@
+---
+title: Staff wellbeing statement
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# Staff wellbeing statement
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**:  St Peter’s School    
+
+**Location**: Huntingdon, Cambridgeshire
+
+**Phase**: Secondary
+
+**Number of pupils**: 1000
+
+**Contact details**: Email the school office at <reception@stpetershuntingdon.org> 
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        Our united approach creates: 
+        <ul>
+          <li>
+            a sense of belonging
+          </li>
+          <li> 
+            a culture that is based upon our core wellbeing principles 
+          </li>
+          <li>
+            an environment that recognises skills and encourages personal development
+          </li>
+          <li>
+            an environment whereby employees feel they are listened to 
+          </li>
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from HR Manager Rachel Boyall
+
+{inset-text}
+
+The staff wellbeing statement outlined below was developed by our wellbeing focus group. In addition to the statement, the focus group: 
+
+* offers support to staff 
+
+* seeks feedback on how staff are feeling 
+
+* shares resources 
+
+* looks for ways to boost morale 
+
+* uses staff absence to measure wellbeing  
+
+{/inset-text}
+
+## Our principles 
+
+These principles are the cornerstone of our approach to wellbeing at St Peter’s: 
+
+* because we care 
+
+* because everyone matters 
+
+* together we can make a difference 
+
+* this is worth it 
+
+* we are worth it  
+
+* you are worth it 
+
+## Staff wellbeing statement 
+
+St Peter’s recognises its responsibility for the health, safety and welfare of its employees, and understands that wellbeing and performance are linked. We are committed to fostering a culture of co-operation, trust and mutual respect, where all individuals are treated with dignity, and can work at their optimum level.   
+
+We recognise that work-related stress has a negative impact on employees’ wellbeing and that it can take many forms, so it needs to be carefully monitored and addressed at an organisational level.  
+
+At St Peter’s we: 
+
+* carefully plan and agree work-life balance solutions including flexible working practices where possible and appropriate 
+
+* ensure that the right people are recruited to the right jobs and that a good match is obtained between individuals recruited and job descriptions/specifications 
+
+* manage pressures which may affect employees, including the impact of workload, and anticipate likely problems, taking action to reduce the effects of these pressures where possible 
+
+* pay attention to any changes in employee performance or behaviour and promote sympathetic alertness to employees who show signs of being under stress   
+
+* create opportunities for employees to discuss concerns and enable employees to do so in a supportive environment, through one-to-one meetings and feedback sessions 
+
+* provide an Employment Assistant Programme (EAP), which offers a free 24-hour counselling service 
+
+* put in place procedures for line managers to address concerns or absence due to work related stress 
+
+* provide Occupational Health support to employees where appropriate   
+
+* carry out a risk assessment, where necessary, and especially when concerns have been raised, as soon as possible   
+
+* ensure that when staff are absent, proportionate, and supportive contact is maintained with them, at a mutually agreed frequency 
+
+* establish a return-to-work policy that is supportive of employee  
+
+We ask employees to:   
+
+* inform the organisation if they believe work or the work environment poses a risk to their health 
+
+* seek support or help when they think they are experiencing a problem at the earliest opportunity to ensure effective strategies can be implemented 
+
+* act in a manner that respects the health and safety needs of themselves and others whilst in the workplace 
+
+* assist in the development of good practice and aim to not, through their actions or omissions, create unnecessary work for themselves or colleagues 
+
+* treat colleagues and all other persons whom they interact with during the course of their work with consideration, respect and dignity 
+
+* treat in confidence any health-related information disclosed by an employee during discussions with managers or the occupational health service 
+
+* take responsibility for managing their own health and wellbeing outside of work 

--- a/content/staff-wellbeing/staff-wellbeing-statement.md
+++ b/content/staff-wellbeing/staff-wellbeing-statement.md
@@ -52,7 +52,7 @@ colour: blue
   </div>
 </div>
 
-## Background from HR Manager Rachel Boyall
+## Background from Rachel Boyall, HR Manager
 
 {inset-text}
 
@@ -88,21 +88,23 @@ These principles are the cornerstone of our approach to wellbeing at St Peter’
 
 ## Staff wellbeing statement 
 
-St Peter’s recognises its responsibility for the health, safety and welfare of its employees, and understands that wellbeing and performance are linked. We are committed to fostering a culture of co-operation, trust and mutual respect, where all individuals are treated with dignity, and can work at their optimum level.   
+St Peter’s recognises its responsibility for the health, safety and welfare of its employees, and understands that wellbeing and performance are linked. We foster a culture of co-operation, trust and mutual respect, where all individuals are treated with dignity and can work at their optimum level.
 
-We recognise that work-related stress has a negative impact on employees’ wellbeing and that it can take many forms, so it needs to be carefully monitored and addressed at an organisational level.  
+We recognise that work-related stress has a negative impact on employees’ wellbeing and that it can take many forms. It needs to be carefully monitored and addressed at an organisational level.  
 
 At St Peter’s we: 
 
-* carefully plan and agree work-life balance solutions including flexible working practices where possible and appropriate 
+* carefully plan and agree work-life balance solutions, including flexible working practices where possible and appropriate 
 
-* ensure that the right people are recruited to the right jobs and that a good match is obtained between individuals recruited and job descriptions/specifications 
+* ensure that the right people are recruited to the right jobs
 
-* manage pressures which may affect employees, including the impact of workload, and anticipate likely problems, taking action to reduce the effects of these pressures where possible 
+* manage pressures that may affect employees, including the impact of workload
+
+ * anticipate likely problems, taking action to reduce the effects of these pressures where possible 
 
 * pay attention to any changes in employee performance or behaviour and promote sympathetic alertness to employees who show signs of being under stress   
 
-* create opportunities for employees to discuss concerns and enable employees to do so in a supportive environment, through one-to-one meetings and feedback sessions 
+* create opportunities for employees to discuss concerns and enable employees to do so in a supportive environment
 
 * provide an Employment Assistant Programme (EAP), which offers a free 24-hour counselling service 
 
@@ -110,9 +112,9 @@ At St Peter’s we:
 
 * provide Occupational Health support to employees where appropriate   
 
-* carry out a risk assessment, where necessary, and especially when concerns have been raised, as soon as possible   
+* carry out a risk assessment where necessary and addressing any concerns raised as soon as possible
 
-* ensure that when staff are absent, proportionate, and supportive contact is maintained with them, at a mutually agreed frequency 
+* ensure that when staff are absent, proportionate and supportive contact is maintained with them, at a mutually agreed frequency 
 
 * establish a return-to-work policy that is supportive of employee  
 

--- a/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
+++ b/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
@@ -44,7 +44,8 @@ colour: blue
           </li>
           <li>
             continuously reviewing and evaluating our systems in order to support all staff to achieve a healthy work life balance
-          </li>       
+          </li>
+        </ul>
       </p>
     </div>
   </div>

--- a/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
+++ b/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
@@ -1,6 +1,5 @@
 ---
 title: Try ideas to improve staff wellbeing
-layout: /markdown_resource.html.erb
 colour: blue
 ---
 

--- a/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
+++ b/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
@@ -4,7 +4,7 @@ layout: /markdown_resource.html.erb
 colour: blue
 ---
 
-# title
+# Try ideas to improve staff wellbeing
 
 <strong class="govuk-tag">type</strong>
 

--- a/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
+++ b/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
@@ -1,0 +1,104 @@
+---
+title: Try ideas to improve staff wellbeing
+layout: /markdown_resource.html.erb
+colour: blue
+---
+
+# title
+
+<strong class="govuk-tag">type</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: King Charles I school   
+
+**Location**: Worcestershire
+
+**Phase**: Secondary
+
+**Number of pupils**: 1000
+
+**Contact details**: Email deputy headteacher Ruth Allen at <rallen@kingcharles1.worcs.sch.uk> 
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        We made these changes to enable every teacher to become highly effective by:
+        <ul>
+          <li>
+            ensuring every teacher has time to focus on what is important - planning, teaching and feedback
+          </li>
+          <li>
+            believing in simplicity, always taking the shortest route and aiming for maximum impact on student learning with minimal workload for staff
+          </li>
+          <li>
+            continuously reviewing and evaluating our systems in order to support all staff to achieve a healthy work life balance
+          </li>       
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Ruth Allen, Deputy Headteacher
+
+{inset-text}
+
+At King Charles I school we know that teaching is exhilarating and rewarding. But we also recognise that it can be exhausting.  We understand that time is precious and that tired teachers do not make effective teachers. Our aim is for staff to not have to take work home. 
+
+{/inset-text}
+
+## 21 things we did to improve staff wellbeing 
+
+1. Removal of ‘potential cover’ from timetables except for staff who are under their allocated number of lessons. 
+
+2. Removal of pointless, time wasting displays, we are currently in the process of removing all display boards from classrooms and corridors. 
+
+3. No time wasted on routine admin tasks, departments such as reprographics, finance and data are all on hand to support teachers.  
+
+4. Weekly admin support for heads of department.  
+
+5. We use ParentMail and ParentPay to ensure that tutors are not required to collect money or reply slips. 
+
+6. Automated rewards and simple one click recording of achievement points.   
+
+7. Member of SLT responsible for staff workload and wellbeing. 
+
+8. Half termly staff forum so that staff can highlight issues and concerns and we can move the school forward together. 
+
+9. Coffee and tea is provided in both staffrooms at break time. 
+
+10. Food is provided before parents’ evenings and other evening events.  
+
+11. Flu jabs are offered yearly. 
+
+12. Attendance at funerals and graduations is always agreed to. 
+
+13. Paid family leave for carol concerts, Christmas plays etc. 
+
+14. Regular supervision is offered to staff who are dealing with challenging safeguarding issues. 
+
+15. Recognition of birthdays. 
+
+16. Flowers to mothers of newborns and very poorly staff. 
+
+17. Identification of pinch points during the year and consideration of this when creating the yearly calendar. 
+
+18. Pre-planned and published calendar so that staff can plan in advance. 
+
+19. Staff break duties are scheduled on days where they are either free before or after break. 
+
+20. There is no expectation for staff to answer out of hours emails and guidance has been issued to support staff in dealing with communication via email, the use of mobile phones to pick up emails is discouraged. 
+
+21. There are no prizes for looking busy or staying late - work in a way that suits you and make sure you make time for yourself and your family. 
+ 

--- a/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
+++ b/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
@@ -60,21 +60,21 @@ At King Charles I school we know that teaching is exhilarating and rewarding. Bu
 
 ## 21 things we did to improve staff wellbeing 
 
-1. Removal of ‘potential cover’ from timetables except for staff who are under their allocated number of lessons. 
+1. We removed ‘potential cover’ from timetables, except for staff who are under their allocated number of lessons. 
 
-2. Removal of pointless, time wasting displays, we are currently in the process of removing all display boards from classrooms and corridors. 
+2. We are currently in the process of removing all display boards from classrooms and corridors, as they are pointless and waste time. 
 
-3. No time wasted on routine admin tasks, departments such as reprographics, finance and data are all on hand to support teachers.  
+3. We do not waste time on routine admin tasks. Departments such as Reprographics, Finance and Data are all on hand to support teachers.  
 
-4. Weekly admin support for heads of department.  
+4. There is weekly admin support for heads of department.  
 
-5. We use ParentMail and ParentPay to ensure that tutors are not required to collect money or reply slips. 
+5. ParentMail and ParentPay are used to ensure that tutors are not required to collect money or reply slips. 
 
-6. Automated rewards and simple one click recording of achievement points.   
+6. We implemented automated rewards and simple one-click recording of achievement points.   
 
-7. Member of SLT responsible for staff workload and wellbeing. 
+7. A member of senior leadership team (SLT) is responsible for staff workload and wellbeing. 
 
-8. Half termly staff forum so that staff can highlight issues and concerns and we can move the school forward together. 
+8. A half-termly staff forum takes place so that staff can highlight issues and concerns, and we can move the school forward together. 
 
 9. Coffee and tea is provided in both staffrooms at break time. 
 
@@ -84,21 +84,21 @@ At King Charles I school we know that teaching is exhilarating and rewarding. Bu
 
 12. Attendance at funerals and graduations is always agreed to. 
 
-13. Paid family leave for carol concerts, Christmas plays etc. 
+13. Paid family leave is offered for carol concerts, Christmas plays etc. 
 
 14. Regular supervision is offered to staff who are dealing with challenging safeguarding issues. 
 
-15. Recognition of birthdays. 
+15. We recognise staff birthdays. 
 
-16. Flowers to mothers of newborns and very poorly staff. 
+16. We arrange flowers for new parents and very poorly staff. 
 
-17. Identification of pinch points during the year and consideration of this when creating the yearly calendar. 
+17. We identify pinch points during the year and consider this when creating the yearly calendar. 
 
-18. Pre-planned and published calendar so that staff can plan in advance. 
+18. There is a pre-planned and published calendar so that staff can plan in advance. 
 
 19. Staff break duties are scheduled on days where they are either free before or after break. 
 
-20. There is no expectation for staff to answer out of hours emails and guidance has been issued to support staff in dealing with communication via email, the use of mobile phones to pick up emails is discouraged. 
+20. There is no expectation for staff to answer out-of-hours emails. Guidance has been issued to support staff to deal with communication via email. The use of mobile phones to pick up emails is discouraged. 
 
-21. There are no prizes for looking busy or staying late - work in a way that suits you and make sure you make time for yourself and your family. 
+21. There are no prizes for looking busy or staying late. Work in a way that suits you and make sure you make time for yourself and your family. 
  

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-out-a-clear-and-consistent-approach-to-behaviour-management.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-out-a-clear-and-consistent-approach-to-behaviour-management.md
@@ -1,6 +1,5 @@
 ---
 title: Set out a clear and consistent approach to behaviour management
-layout: /markdown_resource.html.erb
 ---
 
 # Set out a clear and consistent approach to behaviour management

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-up-a-centralised-system-to-record-monitor-and-reward-pupil-behaviour.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-up-a-centralised-system-to-record-monitor-and-reward-pupil-behaviour.md
@@ -1,6 +1,5 @@
 ---
 title: Set up a centralised system to record, monitor and reward pupil behaviour
-layout: /markdown_resource.html.erb
 ---
 
 # Set up a centralised system to record, monitor and reward pupil behaviour

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/try-ideas-to-manage-behaviour-management-workload.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/try-ideas-to-manage-behaviour-management-workload.md
@@ -1,6 +1,5 @@
 ---
 title: Try ideas to manage behaviour management workload
-layout: /markdown_resource.html.erb
 ---
 
 # Try ideas to manage behaviour management workload

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/school-email-protocol.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/school-email-protocol.md
@@ -60,7 +60,7 @@ This protocol aims to alleviate the pressure of perceived expectations and contr
 
 ## The school email protocol 
 
-Staff are not expected to check email after 6pm, or over the weekend. For those who want to prepare for the week ahead, a Sunday evening check should be enough. It is a good idea to draw a line under your working day, to maintain a distinction between work life and school life. 
+Staff are not expected to check email outside of working hours. It is a good idea to draw a line under your working day, to maintain a distinction between work life and school life. 
 
 We also decided all emails must have a descriptive heading to make it clear what the email is about. These protocols will be kept under regular review.   
 


### PR DESCRIPTION
Guide to review:
- Check all the links work
- Check for typos or mistakes
- Check all the wellbeing resources are represented
- Check the info for each resource is correct on the staff wellbeing or explore resources page

Questions for design: Should the tag be 'wellbeing' or 'staff wellbeing' on the explore resources page?
I'm not entirely comfy with how the links are the same size as the Headers like 'set a wellbeing vision' - I think this might be an accessibility issue. How should we handle this?