### PR TITLE
[336] Add all identify resources

### DIFF
--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -95,4 +95,15 @@ layout: /explore_resources.html.erb
       created_by: "Hilltop Infant School"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "Share progress with staff",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Template",
+      reading_time: "1 minute",
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -60,4 +60,15 @@ layout: /explore_resources.html.erb
       created_by: "Kensington Primary School"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "Prioritise change using impact graphs",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Template",
+      reading_time: "2 minutes"
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -27,4 +27,14 @@ layout: /explore_resources.html.erb
       resource_type: "Presentation"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "Plan your yearly calendar",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Presentation"
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -83,4 +83,16 @@ layout: /explore_resources.html.erb
       created_by: "Notre Dame High School"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "How we addressed workload issues",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Case study",
+      reading_time: "2 minutes",
+      created_by: "Hilltop Infant School"
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -37,4 +37,15 @@ layout: /explore_resources.html.erb
       resource_type: "Presentation"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "Have structured conversations to identify issues",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Template",
+      reading_time: "1 minute"
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -71,4 +71,16 @@ layout: /explore_resources.html.erb
       reading_time: "2 minutes"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "Create an action plan to reduce workload",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Example",
+      reading_time: "2 minutes",
+      created_by: "Notre Dame High School"
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -48,4 +48,16 @@ layout: /explore_resources.html.erb
       reading_time: "1 minute"
     }
   )%>
+
+  <%= render('/partials/explore_resource_card.*',
+    title: "Use an INSET day to focus on reducing workload",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
+    tag:  "Identify workload issues",
+    tag_colour: "pink",
+    details: {
+      resource_type: "Case study",
+      reading_time: "2 minutes",
+      created_by: "Kensington Primary School"
+    }
+  )%>
 </div>

--- a/content/explore-all-resources/identify-workload-issues.html.erb
+++ b/content/explore-all-resources/identify-workload-issues.html.erb
@@ -9,7 +9,7 @@ layout: /explore_resources.html.erb
 
 <div class="explore-resource-card-group">
   <%= render('/partials/explore_resource_card.*',
-    title: "Staff workload survey",
+    title: "Identify issues using a staff workload survey",
     href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey",
     tag:  "Identify workload issues",
     tag_colour: "pink",
@@ -19,33 +19,12 @@ layout: /explore_resources.html.erb
   )%>
 
   <%= render('/partials/explore_resource_card.*',
-    title: "Identify the issues presentation",
-    href: "#",
+    title: "Act on your staff workload survey",
+    href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey",
     tag:  "Identify workload issues",
     tag_colour: "pink",
     details: {
       resource_type: "Presentation"
-    }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Stuctured conversation template",
-    href: "#",
-    tag:  "Identify workload issues",
-    tag_colour: "pink",
-    details: {
-      resource_type: "Template"
-    }
-  )%>
-
-  <%= render('/partials/explore_resource_card.*',
-    title: "Using an INSET day to focus on reducing workload",
-    href: "#",
-    tag:  "Identify workload issues",
-    tag_colour: "pink",
-    details: {
-      resource_type: "Case study",
-      created_by: "Kensington Primary School"
     }
   )%>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/review-and-streamline-behaviour-management.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/review-and-streamline-behaviour-management.html.erb
@@ -36,7 +36,7 @@ title: Review and streamline behaviour management
         <div class="govuk-grid-column-full">
           <div class="info-box">
             <div class="info-box__corner">
-              <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+              <img src="/assets/images/download-icon.svg" alt="Download icon">
             </div>
             <h2 class="govuk-heading-m">
               Download the presentation

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
@@ -41,7 +41,7 @@ title: Review and streamline communications
         <div class="govuk-grid-column-full">
           <div class="info-box">
             <div class="info-box__corner">
-              <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+              <img src="/assets/images/download-icon.svg" alt="Download icon">
             </div>
             <h2 class="govuk-heading-m">
               Download the presentation

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/review-and-streamline-lesson-planning.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/review-and-streamline-lesson-planning.html.erb
@@ -37,7 +37,7 @@ title: Review and streamline lesson planning
           <div class="govuk-grid-column-full">
             <div class="info-box">
               <div class="info-box__corner">
-                <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+                <img src="/assets/images/download-icon.svg" alt="Download icon">
               </div>
               <h2 class="govuk-heading-m">
                 Download the presentation

--- a/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
@@ -36,7 +36,7 @@ title: Review and streamline data management
           <div class="govuk-grid-column-full">
             <div class="info-box">
               <div class="info-box__corner">
-                <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+                <img src="/assets/images/download-icon.svg" alt="Download icon">
               </div>
               <h2 class="govuk-heading-m">
                 Download the presentation

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
@@ -31,7 +31,7 @@ title: Review and streamline feedback and marking
         <div class="govuk-grid-column-full">
           <div class="info-box">
             <div class="info-box__corner">
-              <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+              <img src="/assets/images/download-icon.svg" alt="Download icon">
             </div>
             <h2 class="govuk-heading-m">
               Download the presentation

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -81,7 +81,14 @@ title: Identify workload issues
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues",
               body: "Talk to staff and teachers about their biggest workload issues.",
               tag: "Template",
-              details: { reading_time: "1 minute"}) %>
+              details: { reading_time: "1 minute" }) %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Use an INSET day to focus on reducing workload",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
+              body: "Read how a school used an INSET day to focus on \"what gets in the way of teaching?\"",
+              tag: "Case study",
+              details: { reading_time: "2 minutes", created_by: "Kensington Primary School" }) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -110,6 +110,13 @@ title: Identify workload issues
               body: "Read tips on how to address workload issues.",
               tag: "Case study",
               details: { reading_time: "2 minutes", created_by: "Hilltop Infant School" }) %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Share progress with staff",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff",
+              body: "Show staff the actions you'll take to address workload issues and gather feedback.",
+              tag: "Template",
+              details: { reading_time: "1 minute" }) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -96,6 +96,13 @@ title: Identify workload issues
               body: "Use an impact graph to measure the impact of different tasks and prioritise change.",
               tag: "Template",
               details: { reading_time: "2 minutes" }) %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Create an action plan to reduce workload",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload",
+              body: "Create an action plan to focus on reducing workload.",
+              tag: "Example",
+              details: { reading_time: "2 minutes", created_by: "Notre Dame High School" }) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -103,6 +103,13 @@ title: Identify workload issues
               body: "Create an action plan to focus on reducing workload.",
               tag: "Example",
               details: { reading_time: "2 minutes", created_by: "Notre Dame High School" }) %>
+
+            <%= render('/partials/resource_card.*',
+              title: "How we addressed workload issues",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues",
+              body: "Read tips on how to address workload issues.",
+              tag: "Case study",
+              details: { reading_time: "2 minutes", created_by: "Hilltop Infant School" }) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -75,6 +75,13 @@ title: Identify workload issues
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar",
               body: "Review your calendar with staff to identify workload issues and resolve them.",
               tag: "Presentation") %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Have structured conversations to identify issues",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues",
+              body: "Talk to staff and teachers about their biggest workload issues.",
+              tag: "Template",
+              details: { reading_time: "1 minute"}) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -59,48 +59,16 @@ title: Identify workload issues
 
           <ul class="resource-card-group">
             <%= render('/partials/resource_card.*',
-              title: "Staff workload survey",
+              title: "Identify issues using a staff workload survey",
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey",
               body: "Gather information from staff and teachers about their biggest workload issues.",
               tag: "Template") %>
 
             <%= render('/partials/resource_card.*',
-              title: "Act on your staff survey",
-              href: "#",
-              body: "Share the results of your survey with staff and decide how to act.",
+              title: "Act on your staff workload survey",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey",
+              body: "Share the results of your workload survey with staff and decide how to act.",
               tag: "Presentation") %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Plan your yearly calendar",
-              href: "#",
-              body: "Review your calendar with staff to identify workload issues and resolve them.",
-              tag: "Presentation") %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Prioritise change using impact graphs",
-              href: "#",
-              body: "Use an impact graph to measure the impact of different tasks and prioritise change.",
-              tag: "Template") %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Have structured conversations with staff",
-              href: "#",
-              body: "Talk to staff and teachers about their biggest workoad issues.",
-              tag: "Template") %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Use an INSET day to focus on reducing workload",
-              href: "#",
-              body: "Read how a school used an INSET day to focus on “what gets in the way of teaching?”" ,
-              tag: "Case study",
-              details: { reading_time: "11 minutes", created_by: "Kensington Primary School"}) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "How we addressed workload issues",
-              href: "#",
-              body: "Read tips on how to address workload issues.",
-              tag: "Case study",
-              details: { reading_time: "2 minutes", created_by: "Hilltop Infant School"}) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -86,7 +86,7 @@ title: Identify workload issues
             <%= render('/partials/resource_card.*',
               title: "Use an INSET day to focus on reducing workload",
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
-              body: "Read how a school used an INSET day to focus on “what gets in the way of teaching?”",
+              body: "Read how a school used an INSET day to focus on what gets in the way of teaching.",
               tag: "Case study",
               details: { reading_time: "2 minutes", created_by: "Kensington Primary School" }) %>
 

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -69,6 +69,12 @@ title: Identify workload issues
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey",
               body: "Share the results of your workload survey with staff and decide how to act.",
               tag: "Presentation") %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Plan your yearly calendar",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar",
+              body: "Review your calendar with staff to identify workload issues and resolve them.",
+              tag: "Presentation") %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -86,9 +86,16 @@ title: Identify workload issues
             <%= render('/partials/resource_card.*',
               title: "Use an INSET day to focus on reducing workload",
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
-              body: "Read how a school used an INSET day to focus on \"what gets in the way of teaching?\"",
+              body: "Read how a school used an INSET day to focus on \“what gets in the way of teaching?\”",
               tag: "Case study",
               details: { reading_time: "2 minutes", created_by: "Kensington Primary School" }) %>
+
+            <%= render('/partials/resource_card.*',
+              title: "Prioritise change using impact graphs",
+              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs",
+              body: "Use an impact graph to measure the impact of different tasks and prioritise change.",
+              tag: "Template",
+              details: { reading_time: "2 minutes" }) %>
           </ul>
         </div>
       </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -86,7 +86,7 @@ title: Identify workload issues
             <%= render('/partials/resource_card.*',
               title: "Use an INSET day to focus on reducing workload",
               href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
-              body: "Read how a school used an INSET day to focus on \“what gets in the way of teaching?\”",
+              body: "Read how a school used an INSET day to focus on “what gets in the way of teaching?”",
               tag: "Case study",
               details: { reading_time: "2 minutes", created_by: "Kensington Primary School" }) %>
 

--- a/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
@@ -18,7 +18,7 @@ staff workload survey, prioritise next steps and identify:
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
       </div>
       <h2 class="govuk-heading-m">
         Download the presentation

--- a/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
@@ -71,6 +71,6 @@ a governor with a particular focus on workload or wellbeing, they may be able 
 help analyse the results. You could also use a more informal approach during a
 whole staff session.
 
-You could also consider how you stagger any changes, see [Plan your yearly calendar](/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar/).
+You could also consider how you stagger any changes, by [planning your yearly calendar](/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar/).
 
 Surveying your staff regularly will help you to measure impact over time.

--- a/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
@@ -1,0 +1,76 @@
+---
+title: Act on your staff workload survey
+colour: pink
+---
+
+# Act on your staff workload survey
+
+<strong class="govuk-tag">Presentation</strong>
+
+This presentation will help you to support a discussion of the results of your
+staff workload survey, prioritise next steps and identify:
+
+- how you can reduce workload without affecting pupil outcomes
+- what you can streamline whilst maintaining standards
+- any areas that are not covered in the survey results
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Download the presentation
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body-s">
+            <strong>Presentation length:</strong> 40 minutes
+          </p>
+          <p class="govuk-body-s">
+            <strong>Resource type:</strong> Presentation
+          </p>
+          <p class="govuk-body-s">
+            <strong>File type:</strong> TBC
+          </p>
+          <p>
+            <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/assets/files/TBC">
+              Download
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+## Audience
+
+This resource has been provided to support senior leadership teams to work with
+the whole school, teams or departments.
+
+## Presentation length
+
+40 minutes to discuss outcomes and next steps with staff.
+
+You should also allocate time for the facilitator to prepare the session for use
+in your school.
+
+## How to run with your staff
+
+You can use the staff workload survey to audit staff workload across your whole
+school, within a particular department or team.
+
+Collecting and analysing the results of your workload survey will create some
+workload in the short term. Staff time should be allocated for this. If you have
+a governor with a particular focus on workload or wellbeing, they may be able to
+help analyse the results. You could also use a more informal approach during a
+whole staff session.
+
+You could also consider how you stagger any changes, see [Plan your yearly calendar](/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar/).
+
+Surveying your staff regularly will help you to measure impact over time.

--- a/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
@@ -1,0 +1,85 @@
+---
+title: Create an action plan to reduce workload
+colour: pink
+---
+
+# Create an action plan to reduce workload
+
+<strong class="govuk-tag">Example</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Notre Dame High School
+
+**Location**: Norwich
+
+**Phase**: Secondary
+
+**Number of pupils**: 1400
+
+**Contact details**: Email Headteacher Neil Cully at <NCully@ndhs.org.uk>
+
+{/inset-text}
+
+## Background from Neil Cully, Headteacher
+
+Notre Dame High School created a wellbeing committee [link to establishing a
+wellbeing committee resource] that issued a workload survey to its staff. They
+used the results to create an action plan which focuses on improving staff
+wellbeing and reducing workload.
+
+The action plan outlines the key areas of focus, the actions that need to be
+taken, what success looks like and the timescale for actions to be taken.
+
+## Creating an action plan
+
+When you create your action plan, Notre Dame High School advise the following:
+
+### Identify the action plan’s objectives
+
+Identify one, or at most two, things that you are going to do to help issues
+prioritised from the workload survey.
+
+### Decide your actions
+
+Work out what you are going to do to reach your objectives.
+
+### Determine your success criteria
+
+Determine how you will know those actions have been achieved, and that you have
+succeeded.
+
+### Decide a time scale for completion of actions
+
+Decide how long you think the above will take you. Note any important milestones
+to include if the timescale is longer, for example, over the whole year.
+
+### Work out what resources you will need
+
+Decide what additional support you will need to achieve the objectives. For
+example, additional time for staff to research new ideas or funding for
+training.
+
+### Decide who is responsible for monitoring progress
+
+This could be one person or group. For example, your senior leadership team or
+wellbeing committee.
+
+### Evaluate and decide any further outcomes
+
+When you have completed the actions on your plan, [evaluate how they went](/workload-reduction-toolkit/evaluate-workload-measures/).
+For example, re-run the workload survey you used to identify the initial issues.
+This evaluation and any further actions should be discussed and agreed with all
+staff.
+
+## Consider these questions when creating an action plan
+
+Notre Dame High School considered the following questions when creating their
+action plan:
+
+- Who are we doing this for?
+- Will it improve the quality of teaching?
+- What impact will it have on students?
+- Can we do this in a more efficient and effective way?

--- a/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
@@ -25,10 +25,9 @@ colour: pink
 
 ## Background from Neil Cully, Headteacher
 
-Notre Dame High School created a wellbeing committee [link to establishing a
-wellbeing committee resource] that issued a workload survey to its staff. They
-used the results to create an action plan which focuses on improving staff
-wellbeing and reducing workload.
+Notre Dame High School [created a wellbeing committee](/staff-wellbeing/establish-a-wellbeing-committee)
+that issued a workload survey to its staff. They used the results to create an
+action plan which focuses on improving staff wellbeing and reducing workload.
 
 The action plan outlines the key areas of focus, the actions that need to be
 taken, what success looks like and the timescale for actions to be taken.

--- a/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
@@ -14,7 +14,7 @@ teachers about their workload issues.
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
       </div>
       <h2 class="govuk-heading-m">
         Download the template
@@ -25,7 +25,7 @@ teachers about their workload issues.
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="govuk-body-s">
-            <strong>Resourced type:</strong> Template
+            <strong>Resource type:</strong> Template
           </p>
           <p class="govuk-body-s">
             <strong>File type:</strong> Document, TBC

--- a/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
@@ -1,0 +1,46 @@
+---
+title: Have structured conversations to identify issues
+colour: pink
+---
+
+# Have structured conversations to identify issues
+
+<strong class="govuk-tag">Template</strong>
+
+A structured conversation template to help gather information from staff and
+teachers about their workload issues.
+
+## Adapt the template
+
+Edit the template to better reflect your school.
+
+Some school leaders might use the staff workload survey first and then
+personalise this structured conversation template based on the results.
+
+## Decide when you’ll have the conversations
+
+Consider when in the school year it would be best to have structured
+conversations.
+
+Some school leaders find it helpful to repeat conversations later, to evaluate
+the impact their actions are having on staff workload.
+
+## Decide who will be involved in the conversations
+
+Consider who should lead the structured conversations. It might be an activity
+to delegate to year group or subject leads.
+
+Decide who should participate in the conversations. They could be through
+one-to-one conversations or groups with staff members from different roles.
+
+## Plan your next steps
+
+Consider how you will act on the results of the conversations. Give yourself
+time to analyse the results, update your staff and act.
+
+Once you’ve had the structured conversations, decide what actions you need to
+take either during the sessions or afterwards. Some of the resources in the
+[Address workload issues](/workload-reduction-toolkit/address-workload-issues/)
+section might help you with any issues identified. However, the list is not
+exhaustive. You can help other school leaders by sharing what has worked in your
+school.

--- a/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
@@ -10,6 +10,37 @@ colour: pink
 A structured conversation template to help gather information from staff and
 teachers about their workload issues.
 
+<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Download the template
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body-s">
+            <strong>Resourced type:</strong> Template
+          </p>
+          <p class="govuk-body-s">
+            <strong>File type:</strong> Document, TBC
+          </p>
+          <p>
+            <a class="govuk-link govuk-link--no-visited-state" href="#">
+              Download
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Adapt the template
 
 Edit the template to better reflect your school.

--- a/content/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues.md
@@ -1,0 +1,119 @@
+---
+title: How we addressed workload issues
+colour: pink
+---
+
+# How we addressed workload issues
+
+<strong class="govuk-tag">Case study</strong>
+
+{inset-text}
+
+## School details
+
+**School name**: Hilltop Infant school
+
+**Location**: Essex
+
+**Type**: Primary (4-11) and Social, emotional and mental health (SMEH) provision
+
+**Number of pupils**: 225
+
+**Contact details**: Email Head of School, Jane Robinson at <hilltopinf.admin@heartsacademy.uk>
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        We formed our
+        <%= link_to("Trust Workload and Wellbeing group", "https://www.heartsacademytrust.co.uk/workload-and-wellbeing") %>.
+      </p>
+      <p>
+        As a Trust we also developed a Workload and Wellbeing Charter which is
+        updated each September and mid-year if needed to ensure that messages
+        are reinforced. An annual well-being survey also supports schools to
+        understand if the charter is effective and being implemented.
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Jane Robinson, Head of School
+
+We took part in a DfE project to address workload by running a trial of new
+approaches in school. After discussions with staff, we identified that in-school
+communication was driving unnecessary workload and causing additional pressure
+on staff, so we decided to make that our focus of change.
+
+## Our tips for addressing workload issues
+
+### Involve everyone
+
+Approach change as a project and appoint someone to lead it. Everyone needs to
+feel that they have some ownership of the project and to focus on doing the
+things that make most difference to the root of the problem to find workable
+solutions.
+
+### Conduct a survey
+
+Encourage everyone to be honest in their responses. We used the
+[Staff workload survey](/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey)
+in the school workload reduction toolkit and asked staff to complete it
+anonymously.
+
+### Hold an INSET session
+
+Include teaching staff - teachers, HLTAs, SLT - to explore the drivers of
+workload by discussing the results of the surveys. Debate options for moving
+forward, share ideas, consider what seems manageable.
+
+### Decide together how you will assess the success of any change
+
+Make sure that the information collected can be used as measurable results as
+this adds weight to the findings. We would consider running a randomised
+controlled trial for further change projects.
+
+### Prioritise what action to take
+
+Many areas might be identified but you can’t tackle them all at once. For us, we
+prioritised internal communications.
+
+### Explore the workload issue
+
+Once we’d decided to focus on internal communications, we issued an additional
+very short 5 question multiple choice survey to dig deeper and staff agreed to
+complete a very simple ‘hours worked’ tracker to identify essential and
+non-essential activity.
+
+### Monitor implementation and outcomes
+
+We repeated the survey and tracker (in the middle and end of the project)
+feeding back to staff, reflecting and adapting as necessary.
+
+### Maximise the outcomes
+
+Share and disseminate what you learn and the actions you take through your
+Trust or local networks.
+
+### Communicate with staff
+
+Give and receive feedback throughout. Regular updates, revisits, monitoring are
+all needed if the change is to become part of the organisation’s psyche.
+
+### Empower all staff
+
+Hold each other to account for the commitment to workload reduction.
+
+### Create a wellbeing and workload group
+
+Create a group in your school, trust or across local networks. Show the
+importance of addressing workload and wellbeing by having a dedicated page on
+your website.

--- a/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
@@ -1,0 +1,88 @@
+---
+title: Plan your yearly calendar
+colour: pink
+---
+
+# Plan your yearly calendar
+
+<strong class="govuk-tag">Presentation</strong>
+
+Use this presentation in a staff meeting or INSET day to review your yearly
+calendar.
+
+The presentation includes:
+
+- an exercise to discuss and map the current yearly calendar
+- discussions about what aspects could be changed, streamlined or stopped
+- review of the yearly plan and pinch points
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Download the presentation
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body-s">
+            <strong>Presentation length:</strong> 1 hour 15 minutes
+          </p>
+          <p class="govuk-body-s">
+            <strong>Resource type:</strong> Presentation
+          </p>
+          <p class="govuk-body-s">
+            <strong>File type:</strong> TBC
+          </p>
+          <p>
+            <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/assets/files/TBC">
+              Download
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+## Audience
+
+This resource has been provided to support senior leadership teams to work with
+the whole school, teams or departments.
+
+## Presentation length
+
+1 hour 15 minutes. You should also allocate time for the facilitator to prepare
+the session for use in your school.
+
+## How to run with your staff 
+
+Use this presentation to map out your school year, considering how it impacts on
+workload. Decide if elements can be streamlined, removed, or can take place at a
+different time of year.
+
+When adding to the calendar keep asking the question: If I do this at this point
+in the year, what will be the impact on workload? If the impact is high, then
+reconsider the timings.
+
+At the end of your session, you should decide how actions are recorded and
+reviewed, who is responsible, and how you will communicate changes with staff,
+governors, pupils and parents or carers.
+
+Decide whether the exercise will be completed individually, in teams or
+departments, before discussing together.
+
+Senior leadership teams are likely to want to oversee the process, they could
+also consider if it is more appropriate for another member of staff to
+facilitate the session and lead on follow-up, for example, a head of department.
+
+You might also wish to consider asking somebody independent to facilitate the
+workshop to free up time to take part.
+
+The key to success is providing a supportive environment for open and honest
+professional dialogue.

--- a/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
@@ -20,7 +20,7 @@ The presentation includes:
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Bullseye icon">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
       </div>
       <h2 class="govuk-heading-m">
         Download the presentation

--- a/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
@@ -57,8 +57,8 @@ the whole school, teams or departments.
 
 ## Presentation length
 
-1 hour 15 minutes. You should also allocate time for the facilitator to prepare
-the session for use in your school.
+The presentation should take 1 hour and 15 minutes. You should also allocate
+time for the facilitator to prepare the session for use in your school.
 
 ## How to run with your staff 
 

--- a/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
@@ -15,7 +15,7 @@ one-to-ones, or in team or whole staff meetings.
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
       </div>
       <h2 class="govuk-heading-m">
         Download the impact graph template
@@ -26,7 +26,7 @@ one-to-ones, or in team or whole staff meetings.
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="govuk-body-s">
-            <strong>Resourced type:</strong> Template
+            <strong>Resource type:</strong> Template
           </p>
           <p class="govuk-body-s">
             <strong>File type:</strong> Document, TBC

--- a/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
@@ -51,13 +51,10 @@ If a task has:
 
 - a low workload and a high impact on teaching and learning, this suggests the
   task is worthwhile and doesn’t require any changes
-
 - a high workload and a high impact on teaching and learning, this suggests the
   task is still worth completing but should be streamlined if possible
-
 - a low workload and a low impact on teaching and learning, consider whether it
   could be amended to have a higher impact or discontinued
-
 - a high workload and a low impact on teaching and learning, it should be
   amended, refined or discontinued as soon as possible
 

--- a/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
@@ -1,0 +1,100 @@
+---
+title: Prioritise change using impact graphs
+colour: pink
+---
+
+# Prioritise change using impact graphs
+
+<strong class="govuk-tag">Template</strong>
+
+Impact graphs are used to measure the impact of different tasks and prioritise
+change. This template is designed for use by senior leadership teams in staff
+one-to-ones, or in team or whole staff meetings.
+
+<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Download the impact graph template
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body-s">
+            <strong>Resourced type:</strong> Template
+          </p>
+          <p class="govuk-body-s">
+            <strong>File type:</strong> Document, TBC
+          </p>
+          <p>
+            <a class="govuk-link govuk-link--no-visited-state" href="#">
+              Download
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+## What an impact graph does
+
+An impact graph considers the workload for each task a staff member or team
+does, and the impact the tasks have on teaching and learning.
+
+If a task has:
+
+- a low workload and a high impact on teaching and learning, this suggests the
+  task is worthwhile and doesn’t require any changes
+
+- a high workload and a high impact on teaching and learning, this suggests the
+  task is still worth completing but should be streamlined if possible
+
+- a low workload and a low impact on teaching and learning, consider whether it
+  could be amended to have a higher impact or discontinued
+
+- a high workload and a low impact on teaching and learning, it should be
+  amended, refined or discontinued as soon as possible
+
+## How to use the impact graph to prioritise change
+
+### Identify the tasks that contribute to workload
+
+Talk about all the tasks that make up the staff member’s or team’s workload.
+Write each task on separate post-it notes as you discuss them.
+
+Examples of tasks could include:
+
+- feedback and marking
+- data collection and analysis
+- summative assessments
+- lesson planning and finding resources
+- communications, including staff meetings and emails
+- calendar or time constraints
+- administration and finance
+
+### Prioritise which tasks to change
+
+After you've listed all the tasks, talk about how much work each one involves
+and its impact. Then, put each task in the corresponding spot on the impact
+graph.
+
+## Next steps
+
+Tasks identified as high workload and low impact should be your main area of
+focus. Consider whether these practices could be stopped, amended to make them
+less time-intensive, or refined so they have more impact.
+
+If the tasks written on the post-it notes have been thought about more broadly,
+you may now want to explore each one in more depth. Think about whether there
+are any tasks that can be refined to reduce workload and increase impact, or
+stopped altogether.
+
+You can use the [Address workload issues](/workload-reduction-toolkit/address-workload-issues/)
+section of the workload reduction toolkit to address any specific workload
+issues you identify.

--- a/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
@@ -1,0 +1,72 @@
+---
+title: Share progress with staff
+colour: pink
+---
+
+# Share progress with staff
+
+<strong class="govuk-tag">Template</strong>
+
+Use this template to show your staff the actions you will take to address
+workload issues identified in your school.
+
+<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Download the template
+      </h2>
+      <div class="govuk-grid-row info-box__download-content">
+        <div class="govuk-grid-column-one-half">
+          <img src="/assets/images/preview-placeholder.jpg" alt="Placeholder image" class="dfe-file-preview-image">
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body-s">
+            <strong>Resourced type:</strong> Template
+          </p>
+          <p class="govuk-body-s">
+            <strong>File type:</strong> Document, TBC
+          </p>
+          <p>
+            <a class="govuk-link govuk-link--no-visited-state" href="#">
+              Download
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+## How to use the table to share progress with staff
+
+Use the table to share the workload issues you have identified in your school
+and the actions you plan to take to reduce workload.
+
+The template follows the ‘we discovered, we did, we found’ format:
+
+### ‘We discovered’
+
+These are the workload issues you have identified in your school based on your
+staff’s views.
+
+### ‘We did’
+
+These are the actions you plan to take to address the issues you identified.
+
+You can use the [Address workload issues](/workload-reduction-toolkit/address-workload-issues/)
+section of the workload reduction toolkit to help address specific workload
+issues. It may be helpful to include who is responsible and date targets for
+each action.
+
+### ‘We found’
+
+Once you have addressed a workload issue, speak with your staff again to assess
+how their workload and views have changed.
+
+You can use the [Evaluate workload meaures](/workload-reduction-toolkit/evaluate-workload-measures/)
+section of the workload reduction toolkit to help you evaluate and monitor the
+impact of your workload reduction measures.

--- a/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
@@ -14,7 +14,7 @@ workload issues identified in your school.
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
       </div>
       <h2 class="govuk-heading-m">
         Download the template
@@ -25,7 +25,7 @@ workload issues identified in your school.
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="govuk-body-s">
-            <strong>Resourced type:</strong> Template
+            <strong>Resource type:</strong> Template
           </p>
           <p class="govuk-body-s">
             <strong>File type:</strong> Document, TBC

--- a/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
@@ -15,7 +15,7 @@ resources from the workload reduction toolkit.
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+        <img src="/assets/images/download-icon.svg" alt="Download icon">
       </div>
       <p>
         The survey can be edited to meet the needs of your setting and

--- a/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
@@ -15,7 +15,7 @@ resources from the workload reduction toolkit.
   <div class="govuk-grid-column-full">
     <div class="info-box">
       <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
+        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
       </div>
       <p>
         The survey can be edited to meet the needs of your setting and
@@ -62,7 +62,7 @@ resources from the workload reduction toolkit.
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="govuk-body-s">
-            <strong>Resourced type:</strong> Template
+            <strong>Resource type:</strong> Template
           </p>
           <p class="govuk-body-s">
             <strong>File type:</strong> Document, 70KB, 5 pages

--- a/content/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload.md
@@ -11,7 +11,7 @@ colour: pink
 
 ## School details
 
-**School name**:Kensington Primary School
+**School name**: Kensington Primary School
 
 **Location**: Newham
 

--- a/content/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload.md
@@ -1,0 +1,96 @@
+---
+title: Use an INSET day to focus on reducing workload
+colour: pink
+---
+
+# Use an INSET day to focus on reducing workload
+
+<strong class="govuk-tag">Case study</strong>
+
+{inset-text}
+
+## School details
+
+**School name**:Kensington Primary School
+
+**Location**: Newham
+
+**Phase**: Primary
+
+**Number of pupils**: 700
+
+**Contact details**: Email headteacher Ben Levinson at <info@kensington.ttlt.academy>
+
+{/inset-text}
+
+<div class="govuk-grid-row dfe-width-container">
+  <div class="govuk-grid-column-full">
+    <div class="info-box">
+      <div class="info-box__corner">
+        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
+      </div>
+      <h2 class="govuk-heading-m">
+        Impact and outcomes
+      </h2>
+      <p>
+        We have relentlessly removed unnecessary tasks or reduced them to their
+        essential components, especially when the justification for doing them
+        was ‘that’s what everyone else does’ or ‘that’s what OFSTED, DfE or some
+        other body want. The marking policy (now included in this service’s
+        school workload reduction toolkit) was one outcome of this wider work.
+      </p>
+      <p>
+        As a result, in our most recent wellbeing survey, 95% of our staff
+        believed they completed their work ‘on time’ and, consequently, over 70%
+        answered ‘very much so’ to the question: do you have a life outside
+        work?
+      </p>
+    </div>
+  </div>
+</div>
+
+## Background from Ben Levinson, Headteacher
+
+At Kensington, reducing workload has been an obsession from day one. This INSET
+day was entitled ‘What gets in the way of teaching?’.
+
+We have been through countless iterations since and it has been a key component
+in the development of our culture and ethos.
+
+It is borne from two beliefs:
+
+- teaching 30 children, 5 lessons per day, 5 days per week, is a full-time job
+  in itself
+- inspiring teachers have the time and energy to focus on what matters and have
+  a life outside of school
+
+## Create an agenda for the INSET day
+
+The agenda for the first INSET day was simple:
+
+Staff worked in groups to come up with a list of the things that get in the way
+of them doing the best possible job of teaching our pupils.
+
+They looked at a ‘long list’ of the school’s initiatives. For example, things
+like how we teach reading or mark pupils’ work, the housepoints system,
+attendance initiatives, interventions.
+
+They then decided what worked and what didn’t.
+
+We then categorised these and worked to remove everything that didn’t have a
+direct impact on our pupils.
+
+## Act on what you find out
+
+Inevitably, marking was a key part of this. Our approach to marking was based on
+research from the likes of the Education Endowment Foundation and John Hattie.
+So we encouraged and supported staff to mark more in the lesson – as immediate
+feedback can have a greater impact. We also ensured that marking was there for
+the children, not for myself, my senior team, or anyone else.
+
+This marking policy was one outcome of this wider work.
+
+## Follow up with staff
+
+We followed up the INSET day with a simple ‘We said, We did’ table to show that
+we had listened and acted to remove the barriers to effective teaching.


### PR DESCRIPTION
## Changes in this PR

- Adds all remaining identify resources with pink colour scheme
- **BONUS**: I reviewed all the info-box icons across the site and fixed some alt texts. I swapped some presentation icons to be the download icon as per prototype.

## NOT in this PR

Any downloads or updates to the download box for two links.

## Guidance to review

https://trello.com/c/WFCQiHAR/336-add-the-rest-of-the-identify-resources

- Check content of each resource
- Check links WITHIN each resource
- Check that the resources are linked to correctly from the identify page and the explore resources area