### PR TITLE
[343] Horizontal line colours

### DIFF
--- a/content/assets/css/_feedback-sections.scss
+++ b/content/assets/css/_feedback-sections.scss
@@ -50,14 +50,10 @@
 //
 // Only do this on desktop size. On smaller screens the section drops to the
 // bottom.
-.markdown-page {
-  .govuk-grid-column-one-third {
-    .feedback-section-container {
-      margin-top: govuk-spacing(9);
+.govuk-section-break-feedback {
+  margin-top: govuk-spacing(9);
 
-      @media only screen and (min-width: 630px) {
-        margin-top: 125px;
-      }
-    }
+  @media only screen and (min-width: 630px) {
+    margin-top: 125px;
   }
 }

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -338,16 +338,25 @@ main {
   .govuk-inset-text {
     border-color: govuk_colour("purple");
   }
+  .govuk-section-break--thick {
+    border-color: govuk-colour("purple");
+  }
 }
 
 .content-section--pink {
   .govuk-inset-text {
     border-color: #d4357f;
   }
+  .govuk-section-break--thick {
+    border-color: #d4357f;
+  }
 }
 
 .content-section--green {
   .govuk-inset-text {
+    border-color: #279b91;
+  }
+  .govuk-section-break--thick {
     border-color: #279b91;
   }
 }
@@ -401,11 +410,8 @@ main {
 }
 
 .govuk-section-break--thick {
-  border-width: 4px;
-}
-
-.govuk-section-break--blue {
   border-color: govuk-colour("blue");
+  border-width: 4px;
 }
 
 .two-column-page {

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -26,12 +26,8 @@ title: Staff wellbeing
     <div class="govuk-grid-row two-column-page">
       <div class="govuk-grid-column-two-thirds">
 
-        <div class="govuk-grid-row dfe-width-container">
-          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-        </div>
-
         <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-          <div class="info-box">
+          <div class="info-box govuk-!-margin-top-6">
             <div class="info-box__corner">
               <img src="<%= @base_url %>/assets/images/i-icon.svg" alt="info icon">
             </div>

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -113,7 +113,7 @@ title: Staff wellbeing
         </div>
       </div>
       <div class="govuk-grid-column-one-third govuk-!-padding-top-0">
-        <hr class="govuk-section-break--blue govuk-section-break--thick govuk-!-margin-top-6">
+        <hr class="govuk-section-break--thick govuk-!-margin-top-6">
 
         <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
           <h2 class="govuk-heading-m">Promote wellbeing and flexible working in your school</h2>
@@ -132,7 +132,7 @@ title: Staff wellbeing
           </p>
         </div>
 
-        <hr class="govuk-section-break--blue govuk-section-break--thick">
+        <hr class="govuk-section-break--thick">
 
         <%= render '/partials/feedback.*' %>
       </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
@@ -151,10 +151,9 @@ title: Review and streamline communications
       </div>
     </div>
 
-    <div class="govuk-grid-column-one-third govuk-!-padding-top-7">
-      <div class="govuk-!-margin-top-9 govuk-!-padding-top-9">
-        <%= render '/partials/feedback.*', colour: "purple" %>
-      </div>
+    <div class="govuk-grid-column-one-third">
+      <hr class="govuk-section-break--thick govuk-section-break-feedback">
+      <%= render '/partials/feedback.*', colour: "purple" %>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
@@ -132,10 +132,9 @@ title: Review and streamline data management
       </div>
     </div>
 
-    <div class="govuk-grid-column-one-third govuk-!-padding-top-7">
-      <div class="govuk-!-margin-top-9 govuk-!-padding-top-9">
-        <%= render '/partials/feedback.*', colour: "purple" %>
-      </div>
+    <div class="govuk-grid-column-one-third">
+      <hr class="govuk-section-break--thick govuk-section-break-feedback">
+      <%= render '/partials/feedback.*', colour: "purple" %>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
@@ -137,10 +137,9 @@ title: Review and streamline feedback and marking
       </div>
     </div>
 
-    <div class="govuk-grid-column-one-third govuk-!-padding-top-7">
-      <div class="govuk-!-margin-top-9 govuk-!-padding-top-9">
-        <%= render '/partials/feedback.*', colour: "purple" %>
-      </div>
+    <div class="govuk-grid-column-one-third">
+      <hr class="govuk-section-break--thick govuk-section-break-feedback">
+      <%= render '/partials/feedback.*', colour: "purple" %>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures.html.erb
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures.html.erb
@@ -6,7 +6,7 @@ colour: green
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container govuk-grid-row two-column-page">
     <div class="dfe-width-container govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Evaluate workload measures</h1>
         <p>
           These resources help you track and evaluate the impact of your
@@ -21,8 +21,6 @@ colour: green
     
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <hr class="govuk-section-break--thick">
-
         <div class="govuk-grid-row dfe-width-container content-section--green">
           <div class="info-box">
             <div class="info-box__corner">

--- a/content/workload-reduction-toolkit/evaluate-workload-measures.html.erb
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures.html.erb
@@ -4,7 +4,7 @@ colour: green
 ---
 
 <div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page">
+  <div class="dfe-width-container govuk-grid-row two-column-page content-section--green">
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Evaluate workload measures</h1>
@@ -21,7 +21,7 @@ colour: green
     
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-grid-row dfe-width-container content-section--green">
+        <div class="govuk-grid-row dfe-width-container">
           <div class="info-box">
             <div class="info-box__corner">
               <img src="/assets/images/i-icon.svg" alt="info icon">

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -4,7 +4,7 @@ colour: pink
 ---
 
 <div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page">
+  <div class="dfe-width-container govuk-grid-row two-column-page content-section--pink">
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="govuk-heading-l">Identify workload issues</h1>
@@ -17,7 +17,7 @@ colour: pink
     
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-grid-row dfe-width-container content-section--pink">
+        <div class="govuk-grid-row dfe-width-container">
           <div class="info-box">
             <div class="info-box__corner">
               <img src="/assets/images/i-icon.svg" alt="info icon">

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -17,8 +17,6 @@ colour: pink
     
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <hr class="govuk-section-break--thick">
-
         <div class="govuk-grid-row dfe-width-container content-section--pink">
           <div class="info-box">
             <div class="info-box__corner">

--- a/layouts/markdown_resource.html.erb
+++ b/layouts/markdown_resource.html.erb
@@ -4,8 +4,9 @@
       <div class="govuk-grid-column-two-thirds">
         <%= yield %>
         <%= render '/partials/share_this_resource.*' %>
-      </div>  
+      </div>
       <div class="govuk-grid-column-one-third">
+        <hr class="govuk-section-break--thick govuk-section-break-feedback">
         <%= render('/partials/feedback.*', colour: @item[:colour] || "purple") %>
       </div>
     </div>

--- a/layouts/workload_topic_section.html.erb
+++ b/layouts/workload_topic_section.html.erb
@@ -12,8 +12,6 @@
 
     <div class="dfe-width-container govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <hr class="govuk-section-break--thick">
-
         <div class="govuk-grid-row dfe-width-container">
           <div class="info-box">
             <div class="info-box__corner">


### PR DESCRIPTION
## Changes in this PR

- Remove the section breaks from above main text on all pages (topic pages and resources)
- Add section breaks above feedback sections

## Guidance to review

https://trello.com/c/2GV9ReTV/343-remove-horizontal-break-lines-on-main-text-and-add-horizontal-break-line-above-share-your-ideas

- Check that the section break colours match which section they're in
- Check we're not missing any
- Check it looks ok on mobile

<img width="1154" alt="Screenshot 2024-03-06 at 16 31 34" src="https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/assets/18436946/d08cdaf9-dc9a-411d-a622-ef76e13e708e">
