### PR TITLE
[342] Swap order of sections and make titles HTML headings

### DIFF
--- a/content/main.html.erb
+++ b/content/main.html.erb
@@ -29,21 +29,23 @@ title: Home
   <div class="govuk-width-container dfe-width-container">
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-half card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/staff-wellbeing">
-          <p class="govuk-body-l dfe-card-header">
-            Staff wellbeing
-          </p>
+        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit">
+          <h2 class="govuk-body-l dfe-card-header">
+            Workload reduction toolkit
+          </h2>
           <div class="dfe-card-body">
-            <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
+            <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
           </div>
         </a>
       </li>
 
       <li class="govuk-grid-column-one-half card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit">
-          <p class=" govuk-body-l dfe-card-header">Workload reduction toolkit</p>
+        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/staff-wellbeing">
+          <h2 class="govuk-body-l dfe-card-header">
+            Staff wellbeing
+          </h2>
           <div class="dfe-card-body">
-            <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
+            <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
           </div>
         </a>
       </li>

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -35,29 +35,39 @@ title: Workload reduction toolkit
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-third card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/identify-workload-issues">
-          <p class="dfe-card-header dfe-card-header--pink">
+          <h3 class="dfe-card-header dfe-card-header--pink govuk-body">
             Identify workload issues
-          </p>
+          </h3>
           <div class="dfe-card-body">
-            <p class="govuk-body">Identify workload issues and prioritise where to act</p>
+            <p class="govuk-body">
+              Identify workload issues and prioritise where to act
+            </p>
           </div>
         </a>
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues">
-          <p class="dfe-card-header dfe-card-header--purple">Address workload issues</p>
+          <h3 class="dfe-card-header dfe-card-header--purple govuk-body">
+            Address workload issues
+          </h3>
           <div class="dfe-card-body">
-            <p class="govuk-body">Take action to reduce workload</p>
+            <p class="govuk-body">
+              Take action to reduce workload
+            </p>
           </div>
         </a>
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/evaluate-workload-measures">
-          <p class="dfe-card-header dfe-card-header--green">Evaluate workload measures</p>
+          <h3 class="dfe-card-header dfe-card-header--green govuk-body">
+            Evaluate workload measures
+          </h3>
           <div class="dfe-card-body">
-            <p class="govuk-body">Track and evaluate workload reduction measures</p>
+            <p class="govuk-body">
+              Track and evaluate workload reduction measures
+            </p>
           </div>
         </a>
       </li>

--- a/layouts/base.html.erb
+++ b/layouts/base.html.erb
@@ -64,9 +64,9 @@
               </svg>
             </a>
           </li>
-          <li class="dfe-header__navigation-item <%= active_nav_class('/staff-wellbeing/') %>">
-            <a class="dfe-header__navigation-link" href="<%= @base_url %>/staff-wellbeing">
-              Staff wellbeing
+          <li class="dfe-header__navigation-item <%= active_nav_class('/workload-reduction-toolkit/') %>">
+            <a class="dfe-header__navigation-link" href="<%= @base_url %>/workload-reduction-toolkit">
+              Workload reduction toolkit
               <svg class="dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
                 aria-hidden="true" width="34" height="34">
                 <path
@@ -75,9 +75,9 @@
               </svg>
             </a>
           </li>
-          <li class="dfe-header__navigation-item <%= active_nav_class('/workload-reduction-toolkit/') %>">
-            <a class="dfe-header__navigation-link" href="<%= @base_url %>/workload-reduction-toolkit">
-              Workload reduction toolkit
+          <li class="dfe-header__navigation-item <%= active_nav_class('/staff-wellbeing/') %>">
+            <a class="dfe-header__navigation-link" href="<%= @base_url %>/staff-wellbeing">
+              Staff wellbeing
               <svg class="dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
                 aria-hidden="true" width="34" height="34">
                 <path


### PR DESCRIPTION
## Changes in this PR

- Swap the order of 'Staff wellbeing' and 'Workload reduction toolkit' boxes on the main page
- Swap the links in the navbar
- Make the headings of the boxes on the main page `<h2>`s
- Make the headings of the boxes on the Workload reduction toolkit `<h3>`s